### PR TITLE
Update GitVersionDumper.php

### DIFF
--- a/src/SuplaBundle/DependencyInjection/GitVersionDumper.php
+++ b/src/SuplaBundle/DependencyInjection/GitVersionDumper.php
@@ -23,7 +23,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class GitVersionDumper {
     public static function dumpVersion() {
-        exec('git describe --tags 2>/dev/null', $output, $result);
+        exec('git describe --tags 2>' . (file_exists('nul') ? 'nul' : '/dev/null'), $output, $result);
         if ($output && $result === 0) {
             $versionFromDescribe = current($output);
             $version = getenv('RELEASE_VERSION') ?: $versionFromDescribe;


### PR DESCRIPTION
Przy instalacji w środowisku Windows wyrzucał błąd:

    SuplaBundle\DependencyInjection\GitVersionDumper::dumpVersion
    System nie może odnaleźć określonej ścieżki.
    Could not detect application version - skipping.