### PR TITLE
Checking if OCR measurement is valid #943

### DIFF
--- a/src/frontend/src/channels/ocr/ocr-history.vue
+++ b/src/frontend/src/channels/ocr/ocr-history.vue
@@ -29,7 +29,7 @@
                     <span v-if="image.processedAt">
                         <span
                             :class="['label', image.measurementValid === null ? 'label-default' : (image.measurementValid ? 'label-success' : 'label-warning')]">
-                            {{ image.resultMeasurement }}
+                            {{ image.measurementValid ? image.resultMeasurement : $t('Error') }}
                         </span>
                     </span>
                     <span class="label label-default" v-else>{{ $t('Waiting') }}</span>

--- a/src/frontend/src/channels/ocr/ocr-history.vue
+++ b/src/frontend/src/channels/ocr/ocr-history.vue
@@ -29,7 +29,7 @@
                     <span v-if="image.processedAt">
                         <span
                             :class="['label', image.measurementValid === null ? 'label-default' : (image.measurementValid ? 'label-success' : 'label-warning')]">
-                            {{ image.measurementValid ? image.resultMeasurement : $t('Error') }}
+                            {{ image.resultMeasurement | valueOrNoneLabel }}
                         </span>
                     </span>
                     <span class="label label-default" v-else>{{ $t('Waiting') }}</span>

--- a/src/frontend/src/common/filters.js
+++ b/src/frontend/src/common/filters.js
@@ -97,6 +97,14 @@ export function formatGpmValue(value, config) {
     return (unitBefore + roundedValue + unitAfter).trim();
 }
 
+export function valueOrNoneLabel(value) {
+    if (value && value.trim()) {
+        return value;
+    }
+
+    return i18n.global.t('None');
+}
+
 Vue.filter('withBaseUrl', withBaseUrl);
 Vue.filter('withDownloadAccessToken', withDownloadAccessToken);
 Vue.filter('deviceTitle', deviceTitle);
@@ -105,3 +113,4 @@ Vue.filter('ellipsis', ellipsis);
 Vue.filter('prettyBytes', prettyBytes);
 Vue.filter('roundToDecimals', roundToDecimals);
 Vue.filter('formatGpmValue', formatGpmValue);
+Vue.filter('valueOrNoneLabel', valueOrNoneLabel);


### PR DESCRIPTION
Displaying 'None' if image measurement value is empty or white-space.

With data:
```
[
  ['imageTakenAt' => '10.12.2024', 'measurementValid' => false, 'resultMeasurement' => 'test', 'processedAt' => true],
  ['imageTakenAt' => '10.12.2024', 'measurementValid' => false, 'resultMeasurement' => '  ', 'processedAt' => true],
  ['imageTakenAt' => '10.12.2024', 'measurementValid' => false, 'resultMeasurement' => null, 'processedAt' => true]
];
```
The result is:
![obraz](https://github.com/user-attachments/assets/51b67d86-07e9-4a59-8631-1f568dc48d10)