### PR TITLE
Increase max delay limit to 48 hours for scenes and reactions

### DIFF
--- a/frontend/src/channels/reactions/params/reaction-condition-duration.vue
+++ b/frontend/src/channels/reactions/params/reaction-condition-duration.vue
@@ -7,7 +7,7 @@
       </div>
     </div>
     <div class="px-4">
-      <TimeIntervalSlider v-model="model" :min="minDuration" :max="3600" seconds class="mt-5" no-fractions />
+      <TimeIntervalSlider v-model="model" :min="minDuration" :max="172800" seconds class="mt-5" no-fractions />
     </div>
   </div>
 </template>

--- a/frontend/src/scenes/scene-operation-delay-slider.vue
+++ b/frontend/src/scenes/scene-operation-delay-slider.vue
@@ -1,5 +1,5 @@
 <template>
-  <TimeIntervalSlider v-model="model" :min="250" :max="3600000">
+  <TimeIntervalSlider v-model="model" :min="250" :max="172800000">
     <template #buttons>
       <a @click="$emit('delete')">
         <fa :icon="faTrash" />

--- a/src/Entity/Main/SceneOperation.php
+++ b/src/Entity/Main/SceneOperation.php
@@ -123,7 +123,7 @@ class SceneOperation implements HasSubject {
         }
         $this->action = $action->getId();
         $this->setActionParam($actionParam);
-        Assertion::between($userDelayMs, 0, 3600000, 'Maximum delay is 60 minutes.'); // i18n
+        Assertion::between($userDelayMs, 0, 172800000, 'Maximum delay is 48 hours.'); // i18n
         $this->userDelayMs = $userDelayMs;
         $this->delayMs = $userDelayMs;
         $this->waitForCompletion = $waitForCompletion;

--- a/src/Model/ValueBasedTriggerValidator.php
+++ b/src/Model/ValueBasedTriggerValidator.php
@@ -442,7 +442,7 @@ class ValueBasedTriggerValidator {
 
     private function validateDuration(array $onChangeTo): void {
         if (isset($onChangeTo['duration_sec'])) {
-            Assert::that($onChangeTo['duration_sec'])->integer()->greaterOrEqualThan(0)->lessOrEqualThan(3600);
+            Assert::that($onChangeTo['duration_sec'])->integer()->greaterOrEqualThan(0)->lessOrEqualThan(172800);
         }
     }
 }

--- a/tests/Entity/SceneTest.php
+++ b/tests/Entity/SceneTest.php
@@ -23,6 +23,7 @@ use App\Entity\Main\Scene;
 use App\Entity\Main\SceneOperation;
 use App\Enums\ChannelFunctionAction;
 use App\Tests\Integration\Traits\UnitTestHelper;
+use Assert\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class SceneTest extends TestCase {
@@ -46,5 +47,21 @@ class SceneTest extends TestCase {
         $scene->setOpeartions([$operation, $operation2]);
         $scene->setOpeartions([$operation2, $operation]);
         $this->assertCount(2, $scene->getOperations());
+    }
+
+    public function testAcceptsMaximumDelay() {
+        $operation = new SceneOperation($this->createMock(IODeviceChannel::class), ChannelFunctionAction::OPEN(), [], 172800000);
+        $this->assertEquals(172800000, $operation->getUserDelayMs());
+    }
+
+    public function testRejectsDelayAboveMaximum() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Maximum delay is 48 hours.');
+        new SceneOperation($this->createMock(IODeviceChannel::class), ChannelFunctionAction::OPEN(), [], 172800001);
+    }
+
+    public function testDelayOnlyAcceptsMaximumDelay() {
+        $operation = SceneOperation::delayOnly(172800000);
+        $this->assertEquals(172800000, $operation->getUserDelayMs());
     }
 }

--- a/tests/Model/ValueBasedTriggerValidatorTest.php
+++ b/tests/Model/ValueBasedTriggerValidatorTest.php
@@ -73,6 +73,7 @@ class ValueBasedTriggerValidatorTest extends TestCase {
             [ChannelFunction::OPENINGSENSOR_DOOR(), '{"on_change_to": {"ge": 20, "name": "battery_level", "resume": {"lt": 20}}}'],
             [ChannelFunction::OPENINGSENSOR_DOOR(), '{"on_change_to": {"eq": "on", "name": "battery_powered"}}'],
             [ChannelFunction::THERMOMETER(), '{"on_change_to": {"eq": "hi", "name": "connected"}}'],
+            [ChannelFunction::THERMOMETER(), '{"on_change_to": {"eq": "hi", "name": "connected", "duration_sec": 172800}}'],
         ];
     }
 
@@ -116,6 +117,7 @@ class ValueBasedTriggerValidatorTest extends TestCase {
             [ChannelFunction::THERMOMETER(), '{"on_change_to": {"ge": 20}}'],
             [ChannelFunction::HUMIDITY(), '{"on_change_to": {"ge": 20}}'],
             [ChannelFunction::THERMOMETER(), '{"on_change": {}}'],
+            [ChannelFunction::THERMOMETER(), '{"on_change_to": {"eq": "hi", "name": "connected", "duration_sec": 172801}}'],
         ];
     }
 }

--- a/translations/messages.ar.yml
+++ b/translations/messages.ar.yml
@@ -595,7 +595,7 @@ Manual: تعليمات
 Manually closed: مغلق يدويا
 Master thermostat: ثرموستات الماستر
 Max: الحد الأقصى
-Maximum delay is 60 minutes.: الحد الأقصى للتأخير هو 60 دقيقة.
+Maximum delay is 48 hours.: الحد الأقصى للتأخير هو 48 ساعة.
 Maximum duration is one year.: المدة القصوى هي سنة واحدة.
 Maximum filesize limit is {limit}.: الحد الأقصى لحجم الملف هو {limit}.
 Maximum voltage: أعلى جهد

--- a/translations/messages.az.yml
+++ b/translations/messages.az.yml
@@ -672,7 +672,7 @@ Master thermostat: Əsas termostat
 Master thermostat for channel: '@:{''Əsas termostat''} @:{''kanal üçün''}'
 Max: Maks.
 Maximum: Maksimum
-Maximum delay is 60 minutes.: Maksimum gecikmə 60 dəqiqədir.
+Maximum delay is 48 hours.: Maksimum gecikmə 48 saatdır.
 Maximum duration is one year.: Maksimum müddət bir ildir.
 Maximum filesize limit is {limit}.: Maksimum fayl ölçüsü {limit}-dir.
 Maximum voltage: Maksimum gərginlik

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -595,7 +595,7 @@ Manual: Návod
 Manually closed: Uzavřeno ručně
 Master thermostat: Nadřazený termostat
 Max: Max.
-Maximum delay is 60 minutes.: Maximální zpoždění je 60 minut.
+Maximum delay is 48 hours.: Maximální zpoždění je 48 hodin.
 Maximum duration is one year.: Maximální doba je jeden rok.
 Maximum filesize limit is {limit}.: Maksymalny rozmiar pliku to {limit}.
 Maximum voltage: Nejvyšší napětí

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -595,7 +595,7 @@ Manual: Anweisung
 Manually closed: Manuell geschlossen
 Master thermostat: Hauptthermostat
 Max: Max.
-Maximum delay is 60 minutes.: Maximale Verzögerung beträgt 60 Minuten.
+Maximum delay is 48 hours.: Maximale Verzögerung beträgt 48 Stunden.
 Maximum duration is one year.: Maximaler Zeitraum ist ein Jahr.
 Maximum filesize limit is {limit}.: Die maximale Dateigröße ist {limit}.
 Maximum voltage: Höchste Spannung

--- a/translations/messages.el.yml
+++ b/translations/messages.el.yml
@@ -595,7 +595,7 @@ Manual: Οδηγίες
 Manually closed: Κλειστός χειροκίνητα
 Master thermostat: Κύριος θερμοστάτης
 Max: Μέγ.
-Maximum delay is 60 minutes.: Η μέγιστη καθυστέρηση είναι 60 λεπτά.
+Maximum delay is 48 hours.: Η μέγιστη καθυστέρηση είναι 48 ώρες.
 Maximum duration is one year.: Η μέγιστη περίοδος είναι ένα έτος.
 Maximum filesize limit is {limit}.: Το μέγιστο μέγεθος αρχείου είναι {limit}.
 Maximum voltage: Υψηλότερη τάση

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -595,7 +595,7 @@ Manual: Instrucción
 Manually closed: Cerrado manualmente
 Master thermostat: Termostato principal
 Max: Máx.
-Maximum delay is 60 minutes.: El retraso máximo es de 60 minutos.
+Maximum delay is 48 hours.: El retraso máximo es de 48 horas.
 Maximum duration is one year.: El periodo máximo es de un año.
 Maximum filesize limit is {limit}.: El tamaño máximo del archivo es de {limit}.
 Maximum voltage: El voltaje más alto

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -595,7 +595,7 @@ Manual: Instruction
 Manually closed: Fermé manuellement
 Master thermostat: Thermostat principal
 Max: Max.
-Maximum delay is 60 minutes.: Le délai maximal est de 60 minutes.
+Maximum delay is 48 hours.: Le délai maximal est de 48 heures.
 Maximum duration is one year.: La période maximale est d’un an.
 Maximum filesize limit is {limit}.: La taille maximale du fichier est {limit}.
 Maximum voltage: Tension la plus haute

--- a/translations/messages.hu.yml
+++ b/translations/messages.hu.yml
@@ -595,7 +595,7 @@ Manual: Utasítások
 Manually closed: Manuálisan zárva
 Master thermostat: Főtermosztát
 Max: Max.
-Maximum delay is 60 minutes.: A maximális késleltetés 60 perc.
+Maximum delay is 48 hours.: A maximális késleltetés 48 óra.
 Maximum duration is one year.: A maximális időtartam egy év.
 Maximum filesize limit is {limit}.: A maximális fájlméret {limit}.
 Maximum voltage: Legmagasabb feszültség

--- a/translations/messages.it.yml
+++ b/translations/messages.it.yml
@@ -541,7 +541,7 @@ Manual: Istruzioni
 Manually closed: Chiuso manualmente
 Master thermostat: Termostato master
 Max: Max
-Maximum delay is 60 minutes.: Massimo ritardo 60’
+Maximum delay is 48 hours.: Massimo ritardo 48 ore
 Maximum duration is one year.: Durata massima è 1 anno
 Maximum filesize limit is {limit}.: La dimensione massima del file è {limit}.
 Maximum voltage: Tensione più alta

--- a/translations/messages.lt.yml
+++ b/translations/messages.lt.yml
@@ -595,7 +595,7 @@ Manual: Instrukcija
 Manually closed: Uždarytas rankiniu būdu
 Master thermostat: Pagrindinis termostatas
 Max: Maks.
-Maximum delay is 60 minutes.: Maksimalus vėlavimas, tai 60 minučių.
+Maximum delay is 48 hours.: Maksimalus vėlavimas — 48 valandos.
 Maximum duration is one year.: Maksimalus laikotarpis tai vieneri metai.
 Maximum filesize limit is {limit}.: Maksimalus failo dydis tai {limit}.
 Maximum voltage: Aukščiausia įtampa

--- a/translations/messages.nb.yml
+++ b/translations/messages.nb.yml
@@ -595,7 +595,7 @@ Manual: Instruks
 Manually closed: Stengt manuelt
 Master thermostat: Hovedtermostat
 Max: Maks.
-Maximum delay is 60 minutes.: Maksimal forsinkelse er 60 minutter.
+Maximum delay is 48 hours.: Maksimal forsinkelse er 48 timer.
 Maximum duration is one year.: Den maksimale perioden er ett år.
 Maximum filesize limit is {limit}.: Maksimal filstørrelse er {limit}.
 Maximum voltage: Høyeste spenning

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -595,7 +595,7 @@ Manual: Instructies
 Manually closed: Handmatig gesloten
 Master thermostat: Hoofdthermostaat
 Max: Max.
-Maximum delay is 60 minutes.: De maximale vertraging is 60 minuten.
+Maximum delay is 48 hours.: De maximale vertraging is 48 uur.
 Maximum duration is one year.: De maximale periode is één jaar.
 Maximum filesize limit is {limit}.: De maximale bestandsgrootte is {limit}.
 Maximum voltage: Hoogste spanningswaarde

--- a/translations/messages.pl.yml
+++ b/translations/messages.pl.yml
@@ -692,7 +692,7 @@ Master thermostat: Termostat nadrzędny
 Master thermostat for channel: '@:{''Master thermostat''} @:{''for channel''}'
 Max: Maks.
 Maximum: Maksimum
-Maximum delay is 60 minutes.: Maksymalne opóźnienie to 60 minut.
+Maximum delay is 48 hours.: Maksymalne opóźnienie to 48 godzin.
 Maximum duration is one year.: Maksymalny okres to jeden rok.
 Maximum filesize limit is {limit}.: Maksymalny rozmiar pliku to {limit}.
 Maximum voltage: Najwyższe napięcie

--- a/translations/messages.pt.yml
+++ b/translations/messages.pt.yml
@@ -595,7 +595,7 @@ Manual: Instrução
 Manually closed: Fechado manualmente
 Master thermostat: Termóstato principal
 Max: Máx.
-Maximum delay is 60 minutes.: O tempo de atraso máximo é de 60 minutos.
+Maximum delay is 48 hours.: O tempo de atraso máximo é de 48 horas.
 Maximum duration is one year.: O período máximo é de um ano.
 Maximum filesize limit is {limit}.: O tamanho máximo de arquivo é {limit}.
 Maximum voltage: Tensão mais alta

--- a/translations/messages.ro.yml
+++ b/translations/messages.ro.yml
@@ -595,7 +595,7 @@ Manual: Instrucțiune
 Manually closed: Închis manual
 Master thermostat: Termostat principal
 Max: Maks.
-Maximum delay is 60 minutes.: Întârzierea maximă este de 60 de minute.
+Maximum delay is 48 hours.: Întârzierea maximă este de 48 de ore.
 Maximum duration is one year.: Perioada maximă este de un an.
 Maximum filesize limit is {limit}.: Mărimea maximă a fișierului este de {limit}.
 Maximum voltage: Cea mai mare tensiune

--- a/translations/messages.ru.yml
+++ b/translations/messages.ru.yml
@@ -406,7 +406,7 @@ Manage your new client app in the SUPLA-Cloud.: Управление настр�
 Manage your new device in the SUPLA-Cloud or with your smartphone SUPLA app.: Управляйте своим устройством в SUPLA-Cloud или с помощью приложения SUPLA на вашем смартфоне.
 Manual: Инструкция
 Manually closed: Закрыт вручную
-Maximum delay is 60 minutes.: Максимальная задержка - 60 минут.
+Maximum delay is 48 hours.: Максимальная задержка — 48 часов.
 Maximum filesize limit is {limit}.: Максимальный размер файла - {limit}.
 Maximum voltage: Максимальное напряжение
 Measurement window: Время измерения

--- a/translations/messages.sk.yml
+++ b/translations/messages.sk.yml
@@ -595,7 +595,7 @@ Manual: Návod
 Manually closed: Zatvorený manuálne
 Master thermostat: Hlavný termostat
 Max: Max.
-Maximum delay is 60 minutes.: Maximálne oneskorenie je 60 minút.
+Maximum delay is 48 hours.: Maximálne oneskorenie je 48 hodín.
 Maximum duration is one year.: Maximálne obdobie je jeden rok.
 Maximum filesize limit is {limit}.: Maximální velikost souboru je {limit}.
 Maximum voltage: Najvyššie napätie

--- a/translations/messages.sl.yml
+++ b/translations/messages.sl.yml
@@ -595,7 +595,7 @@ Manual: Navodila
 Manually closed: Ročno zaprt
 Master thermostat: Glavni termostat
 Max: Maks.
-Maximum delay is 60 minutes.: Največji zamik je 60 minut.
+Maximum delay is 48 hours.: Največji zamik je 48 ur.
 Maximum duration is one year.: Maksimalno obdobje je eno leto.
 Maximum filesize limit is {limit}.: Največja velikost datoteke je {limit}.
 Maximum voltage: Najvišja napetost

--- a/translations/messages.uk.yml
+++ b/translations/messages.uk.yml
@@ -595,7 +595,7 @@ Manual: Інструкція
 Manually closed: Закривається вручну
 Master thermostat: Головний термостат
 Max: Макс.
-Maximum delay is 60 minutes.: Максимальна затримка становить 60 хвилин.
+Maximum delay is 48 hours.: Максимальна затримка становить 48 годин.
 Maximum duration is one year.: Максимальний термін - один рік.
 Maximum filesize limit is {limit}.: Максимальний розмір файлу становить {limit}.
 Maximum voltage: Найвища напруга

--- a/translations/messages.vi.yml
+++ b/translations/messages.vi.yml
@@ -595,7 +595,7 @@ Manual: Hướng dẫn
 Manually closed: Đóng thủ công
 Master thermostat: Bộ điều chỉnh nhiệt chính
 Max: Tối đa
-Maximum delay is 60 minutes.: Độ trễ tối đa là 60 phút.
+Maximum delay is 48 hours.: Độ trễ tối đa là 48 giờ.
 Maximum duration is one year.: Thời gian tối đa là một năm.
 Maximum filesize limit is {limit}.: Giới hạn kích thước tệp tối đa là {limit}.
 Maximum voltage: Điện áp cao nhất


### PR DESCRIPTION
## What does this PR change?

- Raise the maximum delay for scene operations from 1 hour to 48 hours (backend validation, UI slider, translations).
- Apply the same 48-hour limit to reaction condition duration (`duration_sec`).
- Add unit tests for the new boundaries.

## Checklist

- [x] Linked issue / rationale provided: https://github.com/SUPLA/supla-cloud/issues/1065
- [x] Code follows existing style and conventions
- [x] Documentation updated if needed
- [x] CLA accepted (requested automatically after opening the PR)
- [x] Tests added/updated (if applicable)
- [x] No secrets in logs/config

