### PR TITLE
Fix Hungarian device deletion confirmation dialog

### DIFF
--- a/translations/messages.hu.yml
+++ b/translations/messages.hu.yml
@@ -249,7 +249,7 @@ Confirm Password: Jelszó megerősítése
 Confirm if you want to perform the calibration.: Erősítse meg, hogy el kívánja végezni a kalibrálást.
 Confirm if you want to remove Access Identifier: Erősítse meg, hogy el akarja távolítani a Hozzáférési Azonosítót
 Confirm if you want to remove the Location ID{locationId}. You will no longer be able to connect the i/o devices to this Location.: Erősítse meg, hogy el akarja távolítani a {locationId} helyazonosítót. Nincs további I / O eszköz csatlakozási lehetőség ehhez a lokálizációhoz.
-Confirm if you want to remove {deviceName} device and all of its channels.: Erősítse meg, hogy törölni kívánja a {eszközNév} eszközt és annak összes csatornáját.
+Confirm if you want to remove {deviceName} device and all of its channels.: Erősítse meg, hogy törölni kívánja a {deviceName} eszközt és annak összes csatornáját.
 Confirmation: Megerősítés
 Conflict: Konfliktus
 Connected: Csatlakozva


### PR DESCRIPTION
## What does this PR change?

- Fix a broken `{deviceName}` placeholder in the Hungarian translation of the device deletion confirmation message (`{eszközNév}` was used instead).
- The invalid placeholder caused vue-i18n to fail when rendering the modal, so the dialog was invisible on mobile (while Enter still confirmed deletion).

## Checklist

- [x] Linked issue / rationale provided: https://github.com/SUPLA/supla-cloud/issues/1048
- [x] Code follows existing style and conventions
- [x] Documentation updated if needed
- [x] CLA accepted (requested automatically after opening the PR)
- [x] Tests added/updated (if applicable)
- [x] No secrets in logs/config

