### PR TITLE
Fix 500 error when OAuth redirect_uri is invalid

### DIFF
--- a/frontend/src/common/errors/error-page-status.vue
+++ b/frontend/src/common/errors/error-page-status.vue
@@ -1,5 +1,11 @@
 <template>
-  <ErrorPage :header-i18n="header" :message-i18n="message" :icon="icon" :status-code="statusCode" />
+  <ErrorPage
+    :header-i18n="header"
+    :message-i18n="message"
+    :icon="icon"
+    :status-code="statusCode"
+    :guru-meditation="guruMeditation"
+  />
 </template>
 
 <script setup>
@@ -8,6 +14,7 @@
   const props = defineProps({statusCode: Number});
 
   const statusCode = window.errorDetails?.statusCode || props.statusCode || 404;
+  const guruMeditation = window.errorDetails?.guruMeditation || '';
 
   const header =
     {

--- a/frontend/src/common/errors/error-page.vue
+++ b/frontend/src/common/errors/error-page.vue
@@ -4,16 +4,8 @@
       <h1 class="nocapitalize">{{ $t(headerI18n) }}</h1>
       <i :class="[icon, 'error-page-icon']" style="font-size: 160px"></i>
       <div class="my-3">
-        <h5>{{ $t(messageI18n, {statusCode}) }}</h5>
-      </div>
-      <div v-if="guruMeditation">
-        <button v-if="!guruMeditationVisible" type="button" class="btn btn-link" @click="guruMeditationVisible = true">
-          Guru Meditation <i class="pe-7s-help1"></i>
-        </button>
-        <div v-if="guruMeditationVisible" class="well" style="max-width: 600px; margin: 0 auto">
-          <h3 class="no-margin-top">{{ $t('Guru Meditation') }}</h3>
-          <pre><code>{{ guruMeditation }}</code></pre>
-        </div>
+        <h5 v-if="guruMeditation">{{ guruMeditation }}</h5>
+        <h5 v-else>{{ $t(messageI18n, {statusCode}) }}</h5>
       </div>
       <div class="my-3">
         <router-link to="/">{{ $t('Start from the homepage.') }}</router-link>
@@ -26,10 +18,5 @@
 <script>
   export default {
     props: ['headerI18n', 'messageI18n', 'icon', 'guruMeditation', 'statusCode'],
-    data() {
-      return {
-        guruMeditationVisible: false,
-      };
-    },
   };
 </script>

--- a/src/Controller/OAuth/BrokerAuthorizeController.php
+++ b/src/Controller/OAuth/BrokerAuthorizeController.php
@@ -55,22 +55,13 @@ class BrokerAuthorizeController extends AuthorizeController {
      */
     public function authorizeAction(Request $request): Response {
         try {
-            try {
-                try {
-                    return parent::authorizeAction($request);
-                } catch (OAuthReauthenticateException $exception) {
-                    return new RedirectResponse($request->getUri());
-                } catch (OAuth2RedirectException $redirectException) {
-                    throw $redirectException;
-                } catch (OAuth2ServerException $e) {
-                    throw new ApiException($e->getDescription() ?: 'error', Response::HTTP_BAD_REQUEST, $e);
-                }
-            } catch (ApiException $e) {
-                $this->oauth2Server->finishClientAuthorization(false);
-                throw $e;
-            }
+            return parent::authorizeAction($request);
+        } catch (OAuthReauthenticateException $exception) {
+            return new RedirectResponse($request->getUri());
         } catch (OAuth2RedirectException $redirectException) {
             return new Response('', Response::HTTP_FOUND, $redirectException->getResponseHeaders());
+        } catch (OAuth2ServerException $e) {
+            throw new ApiException($e->getDescription() ?: 'error', Response::HTTP_BAD_REQUEST, $e);
         }
     }
 

--- a/tests/Integration/Auth/OAuthAuthenticationIntegrationTest.php
+++ b/tests/Integration/Auth/OAuthAuthenticationIntegrationTest.php
@@ -122,6 +122,24 @@ class OAuthAuthenticationIntegrationTest extends IntegrationTestCase {
         $response = $client->getResponse();
         $this->assertFalse($response->isRedirection());
         $this->assertStatusCode(400, $response);
+        $this->assertStringContainsString('redirect URI', $response->getContent());
+    }
+
+    public function testTokenRequestForInvalidRedirectUriResultsInError() {
+        $this->makeOAuthAuthorizeRequest();
+        $authCodes = $this->getDoctrine()->getRepository(AuthCode::class)->findByClient($this->client);
+        $client = $this->createClient();
+        $client->apiRequest('POST', '/oauth/v2/token', [
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->client->getPublicId(),
+            'client_secret' => $this->client->getSecret(),
+            'redirect_uri' => 'https://horses.pl',
+            'code' => $authCodes[0]->getToken(),
+        ]);
+        $response = $client->getResponse();
+        $this->assertStatusCode(400, $response);
+        $content = json_decode($response->getContent(), true);
+        $this->assertEquals('redirect_uri_mismatch', $content['error']);
     }
 
     public function testLogsOutAfterGrantingAccess() {


### PR DESCRIPTION
**DRAFT, please do not check or merge**

## What does this PR change?

- Remove erroneous `finishClientAuthorization(false)` call when OAuth authorization fails with a server error (e.g. invalid `redirect_uri`), which caused an uncaught second exception and a 500 response.
- Show the specific error message on the HTTP error page instead of a generic 400 text.

## Checklist

- [x] Linked issue / rationale provided: https://github.com/SUPLA/supla-cloud/issues/1050
- [x] Code follows existing style and conventions
- [x] Documentation updated if needed
- [x] CLA accepted (requested automatically after opening the PR)
- [x] Tests added/updated (if applicable)
- [x] No secrets in logs/config

