### PR TITLE
Notify user when schedule is auto-disabled due to failed executions

### DIFF
--- a/frontend/src/account/account-opt-out-notifications-modal.vue
+++ b/frontend/src/account/account-opt-out-notifications-modal.vue
@@ -73,6 +73,10 @@
             id: 'new_client_app',
             label: 'New client app (smartphone) added to your account', // i18n
           },
+          {
+            id: 'schedule_disabled_due_to_failed_executions',
+            label: 'Schedule disabled due to failed executions', // i18n
+          },
         ],
         selectedNotificationsEmail: {},
         selectedNotificationsPush: {},

--- a/src/Command/Cyclic/DisableBrokenSchedulesCommand.php
+++ b/src/Command/Cyclic/DisableBrokenSchedulesCommand.php
@@ -25,11 +25,13 @@ use App\Enums\ScheduleActionExecutionResult;
 use App\Model\Audit\Audit;
 use App\Model\Schedule\ScheduleManager;
 use App\Model\TimeProvider;
+use App\Message\Common\ScheduleDisabledDueToFailuresNotification;
 use App\Repository\ScheduleRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class DisableBrokenSchedulesCommand extends Command implements CyclicCommand {
     /** @var EntityManagerInterface */
@@ -40,18 +42,22 @@ class DisableBrokenSchedulesCommand extends Command implements CyclicCommand {
     private $scheduleRepository;
     /** @var Audit */
     private $audit;
+    /** @var MessageBusInterface */
+    private $messageBus;
 
     public function __construct(
         EntityManagerInterface $entityManager,
         ScheduleManager $scheduleManager,
         ScheduleRepository $scheduleRepository,
-        Audit $audit
+        Audit $audit,
+        MessageBusInterface $messageBus
     ) {
         parent::__construct();
         $this->entityManager = $entityManager;
         $this->scheduleManager = $scheduleManager;
         $this->scheduleRepository = $scheduleRepository;
         $this->audit = $audit;
+        $this->messageBus = $messageBus;
     }
 
     protected function configure() {
@@ -89,11 +95,12 @@ QUERY;
         while ($scheduleToDisable = $result->fetchAssociative()) {
             /** @var Schedule $schedule */
             $schedule = $this->scheduleRepository->find($scheduleToDisable['id']);
-            $this->scheduleManager->disable($schedule);
+            $this->scheduleManager->disableDueToFailedExecutions($schedule);
             $this->audit->newEntry(AuditedEvent::SCHEDULE_BROKEN_DISABLED())
                 ->setIntParam($schedule->getId())
                 ->setUser($schedule->getUser())
                 ->buildAndFlush();
+            $this->messageBus->dispatch(new ScheduleDisabledDueToFailuresNotification($schedule));
             ++$disabledCount;
         }
         $output->writeln(sprintf('Disabled <info>%d</info> schedules due to failed executions.', $disabledCount));

--- a/src/Entity/Main/ScheduledExecution.php
+++ b/src/Entity/Main/ScheduledExecution.php
@@ -142,4 +142,12 @@ class ScheduledExecution {
     public function getActionParam(): ?array {
         return $this->actionParam ? json_decode($this->actionParam, true) : $this->actionParam;
     }
+
+    public static function createDisabledDueToFailedExecutionsRecord(Schedule $schedule, DateTime $timestamp): self {
+        $execution = new self($schedule, $timestamp, ChannelFunctionAction::DISABLE());
+        $execution->result = ScheduleActionExecutionResult::DISABLED_DUE_TO_FAILED_EXECUTIONS;
+        $execution->resultTimestamp = $timestamp;
+        $execution->consumed = true;
+        return $execution;
+    }
 }

--- a/src/Enums/ScheduleActionExecutionResult.php
+++ b/src/Enums/ScheduleActionExecutionResult.php
@@ -32,6 +32,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @method static ScheduleActionExecutionResult CANCELLED()
  * @method static ScheduleActionExecutionResult EXECUTED_WITHOUT_CONFIRMATION()
  * @method static ScheduleActionExecutionResult VALVE_CLOSED_MANUALLY_OR_FLOODING()
+ * @method static ScheduleActionExecutionResult DISABLED_DUE_TO_FAILED_EXECUTIONS()
  */
 final class ScheduleActionExecutionResult extends Enum {
     const UNKNOWN = 0;
@@ -45,6 +46,7 @@ final class ScheduleActionExecutionResult extends Enum {
     const CANCELLED = 8;
     const EXECUTED_WITHOUT_CONFIRMATION = 9;
     const VALVE_CLOSED_MANUALLY_OR_FLOODING = 10;
+    const DISABLED_DUE_TO_FAILED_EXECUTIONS = 11;
 
     public function __construct($value) {
         parent::__construct($value ?: 0);
@@ -73,6 +75,7 @@ final class ScheduleActionExecutionResult extends Enum {
             self::CANCELLED => 'Cancelled', // i18n
             self::EXECUTED_WITHOUT_CONFIRMATION => 'Executed without confirmation', // i18n
             self::VALVE_CLOSED_MANUALLY_OR_FLOODING => 'Valve closed manually', // i18n
+            self::DISABLED_DUE_TO_FAILED_EXECUTIONS => 'Disabled due to failed executions', // i18n
         ];
     }
 

--- a/src/Message/Common/ScheduleDisabledDueToFailuresNotification.php
+++ b/src/Message/Common/ScheduleDisabledDueToFailuresNotification.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Message\Common;
+
+use App\Entity\Main\Schedule;
+use App\Message\CommonMessage;
+use App\Message\UserOptOutNotifications;
+
+readonly class ScheduleDisabledDueToFailuresNotification extends CommonMessage {
+    public function __construct(Schedule $schedule) {
+        parent::__construct(
+            $schedule->getUser(),
+            UserOptOutNotifications::SCHEDULE_DISABLED_DUE_TO_FAILED_EXECUTIONS,
+            [
+                'schedule' => [
+                    'id' => $schedule->getId(),
+                    'caption' => $schedule->getCaption(),
+                ],
+            ],
+        );
+    }
+}

--- a/src/Message/UserOptOutNotifications.php
+++ b/src/Message/UserOptOutNotifications.php
@@ -8,4 +8,5 @@ class UserOptOutNotifications extends Enum {
     const FAILED_AUTH_ATTEMPT = 'failed_auth_attempt';
     const NEW_IO_DEVICE = 'new_io_device';
     const NEW_CLIENT_APP = 'new_client_app';
+    const SCHEDULE_DISABLED_DUE_TO_FAILED_EXECUTIONS = 'schedule_disabled_due_to_failed_executions';
 }

--- a/src/Model/Schedule/ScheduleManager.php
+++ b/src/Model/Schedule/ScheduleManager.php
@@ -234,6 +234,12 @@ class ScheduleManager {
         $this->entityManager->flush();
     }
 
+    public function disableDueToFailedExecutions(Schedule $schedule) {
+        $historyEntry = ScheduledExecution::createDisabledDueToFailedExecutionsRecord($schedule, $this->getNow());
+        $this->entityManager->persist($historyEntry);
+        $this->disable($schedule);
+    }
+
     public function deleteScheduledExecutions(Schedule $schedule) {
         $this->entityManager->createQueryBuilder()
             ->delete(ScheduledExecution::class, 's')

--- a/src/Resources/views/Email/schedule_disabled_due_to_failed_executions.html.twig
+++ b/src/Resources/views/Email/schedule_disabled_due_to_failed_executions.html.twig
@@ -1,0 +1,22 @@
+{% extends '@Supla/Email/template.html.twig' %}
+
+{% block subject %}
+    {% trans into userLocale %} SUPLA – schedule disabled due to failed executions {% endtrans %}
+{% endblock %}
+
+{% block preheader %}
+    {% trans into userLocale %} A confirmation that your schedule has been disabled automatically. {% endtrans %}
+{% endblock %}
+
+{% block body %}
+    {% apply paragraph %} {% trans into userLocale %} Your schedule has been disabled automatically due to repeated failed executions. {% endtrans %} {% endapply %}
+    {% apply paragraph %}
+        {% trans with {'%scheduleId%': '<b>' ~ schedule.id ~ '</b>'} into userLocale %} Schedule ID: %scheduleId% {% endtrans %}
+        <br>
+        {% if schedule.caption %}
+            {% trans with {'%scheduleCaption%': '<b>' ~ schedule.caption ~ '</b>'} into userLocale %} Schedule name: %scheduleCaption% {% endtrans %}
+        {% endif %}
+    {% endapply %}
+    {% apply paragraph %} {% trans into userLocale %} Check the schedule history for details and re-enable the schedule after fixing the problem. {% endtrans %} {% endapply %}
+    {% apply linkButton(cloudUrl('schedules/' ~ schedule.id)) %} {% trans into userLocale %} See in SUPLA-Cloud {% endtrans %} {% endapply %}
+{% endblock %}

--- a/src/Resources/views/Email/schedule_disabled_due_to_failed_executions.txt.twig
+++ b/src/Resources/views/Email/schedule_disabled_due_to_failed_executions.txt.twig
@@ -1,0 +1,27 @@
+{% extends '@Supla/Email/template.txt.twig' %}
+
+{% block subject %}
+ {% trans into userLocale %} SUPLA – schedule disabled due to failed executions {% endtrans %}
+{% endblock %}
+
+{% block body %}
+{% trans into userLocale %} Welcome! {% endtrans %}
+
+
+{% trans into userLocale %} Your schedule has been disabled automatically due to repeated failed executions. {% endtrans %}
+
+
+{% trans with {'%scheduleId%': schedule.id} into userLocale %} Schedule ID: %scheduleId% {% endtrans %}
+
+{% if schedule.caption %}
+
+{% trans with {'%scheduleCaption%': schedule.caption} into userLocale %} Schedule name: %scheduleCaption% {% endtrans %}
+{% endif %}
+
+
+{% trans into userLocale %} Check the schedule history for details and re-enable the schedule after fixing the problem. {% endtrans %}
+
+
+{{ cloudUrl('schedules/' ~ schedule.id) }}
+
+{% endblock %}

--- a/src/Resources/views/PushMessage/schedule_disabled_due_to_failed_executions.twig
+++ b/src/Resources/views/PushMessage/schedule_disabled_due_to_failed_executions.twig
@@ -1,0 +1,17 @@
+{% extends '@Supla/PushMessage/template.twig' %}
+
+{% block title %}
+    {% trans into userLocale %} Schedule disabled {% endtrans %}
+{% endblock %}
+
+{% block body %}
+
+    {% trans with {'%scheduleId%': schedule.id} into userLocale %} Schedule ID: %scheduleId% {% endtrans %}
+
+    {% if schedule.caption %}
+        {% trans with {'%scheduleCaption%': schedule.caption} into userLocale %} Schedule name: %scheduleCaption% {% endtrans %}
+    {% endif %}
+
+    {% trans into userLocale %} Disabled due to failed executions {% endtrans %}
+
+{% endblock %}

--- a/tests/Entity/ScheduledExecutionTest.php
+++ b/tests/Entity/ScheduledExecutionTest.php
@@ -29,4 +29,15 @@ class ScheduledExecutionTest extends TestCase {
         $execution = new ScheduledExecution($this->createMock(Schedule::class), new DateTime(), ChannelFunctionAction::CLOSE());
         $this->assertEquals(ScheduleActionExecutionResult::UNKNOWN(), $execution->getResult());
     }
+
+    public function testDisabledDueToFailedExecutionsRecord() {
+        $schedule = $this->createMock(Schedule::class);
+        $timestamp = new DateTime('2026-06-20 12:00:00');
+        $execution = ScheduledExecution::createDisabledDueToFailedExecutionsRecord($schedule, $timestamp);
+        $this->assertEquals(ScheduleActionExecutionResult::DISABLED_DUE_TO_FAILED_EXECUTIONS(), $execution->getResult());
+        $this->assertEquals($timestamp, $execution->getPlannedTimestamp());
+        $this->assertEquals($timestamp, $execution->getResultTimestamp());
+        $this->assertEquals(ChannelFunctionAction::DISABLE(), $execution->getAction());
+        $this->assertTrue($execution->isFailed());
+    }
 }

--- a/tests/Integration/Command/Cyclic/DisableBrokenSchedulesCommandIntegrationTest.php
+++ b/tests/Integration/Command/Cyclic/DisableBrokenSchedulesCommandIntegrationTest.php
@@ -18,6 +18,7 @@
 namespace App\Tests\Integration\Command\Cyclic;
 
 use App\Entity\Main\AuditEntry;
+use App\Entity\Main\ScheduledExecution;
 use App\Enums\AuditedEvent;
 use App\Enums\ChannelFunction;
 use App\Enums\ChannelType;
@@ -26,6 +27,7 @@ use App\Enums\ScheduleMode;
 use App\Model\Audit\Audit;
 use App\Model\Schedule\ScheduleManager;
 use App\Tests\Integration\IntegrationTestCase;
+use App\Tests\Integration\TestMailerTransport;
 use App\Tests\Integration\Traits\SuplaApiHelper;
 
 class DisableBrokenSchedulesCommandIntegrationTest extends IntegrationTestCase {
@@ -97,6 +99,28 @@ class DisableBrokenSchedulesCommandIntegrationTest extends IntegrationTestCase {
         $entry = $this->getLatestAuditEntry();
         $this->assertEquals(AuditedEvent::SCHEDULE_BROKEN_DISABLED(), $entry->getEvent());
         $this->assertEquals($this->schedule->getId(), $entry->getIntParam());
+    }
+
+    /** @depends testDisablingScheduleIfALotOfFailedExecutions */
+    public function testCreatesHistoryEntryWhenScheduleDisabledDueToFailedExecutions() {
+        $historyEntry = $this->getEntityManager()->getRepository(ScheduledExecution::class)->findOneBy([
+            'schedule' => $this->schedule,
+            'result' => ScheduleActionExecutionResult::DISABLED_DUE_TO_FAILED_EXECUTIONS,
+        ]);
+        $this->assertNotNull($historyEntry);
+        $this->assertTrue($historyEntry->getResult()->equals(ScheduleActionExecutionResult::DISABLED_DUE_TO_FAILED_EXECUTIONS()));
+        $this->assertNotNull($historyEntry->getResultTimestamp());
+    }
+
+    /** @depends testDisablingScheduleIfALotOfFailedExecutions */
+    public function testSendsEmailWhenScheduleDisabledDueToFailedExecutions() {
+        $this->flushMessagesQueue();
+        $this->assertCount(1, TestMailerTransport::getMessages());
+        $message = TestMailerTransport::getMessages()[0];
+        $this->assertStringContainsString('schedule disabled due to failed executions', strtolower($message->getSubject()));
+        $this->assertStringContainsString((string)$this->schedule->getId(), $message->getHtmlBody());
+        $this->assertStringContainsString('schedules/' . $this->schedule->getId(), $message->getHtmlBody());
+        $this->assertStringContainsString('optOutNotification=schedule_disabled_due_to_failed_executions', $message->getHtmlBody());
     }
 
     private function getLatestAuditEntry(): AuditEntry {

--- a/translations/messages.ar.yml
+++ b/translations/messages.ar.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ... يمكنك مراقبة درجة الحرارة
 10 minutes before sunset, on day 10 of the month, May through August: 10 دقائق قبل غروب الشمس، فقط في اليوم العاشر من الشهر، من مايو إلى أغسطس
 15 minutes after sunrise, every 2 days: بعد 15 دقيقة من شروق الشمس، كل يومين
+A confirmation that your schedule has been disabled automatically.: تأكيد بأنه تم تعطيل الجدول الزمني تلقائياً.
 A confirmation upon successful client app registration.: تأكيد تسجيل تطبيق عملاء جديد.
 A confirmation upon successful device registration.: تأكيد تسجيل الجهاز بنجاح.
 A confirmation upon successful device unlocking.: تأكيد إلغاء قفل الجهاز.
@@ -158,6 +159,7 @@ Brightness level: مستوى السطوع
 Button volume: مستوى صوت الزر
 Buttons upside down: التحكم العكسي في الأزرار
 By signing in, you are authorizing {clientName} to control your devices.: من خلال تسجيل الدخول، فإنك تفوض التطبيق {clientName} للتحكم في أجهزتك.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: راجع سجل الجدول الزمني للتفاصيل وأعد تفعيل الجدول بعد إصلاح المشكلة.
 CLICK TO DISABLE: أنقر لإيقاف التشغيل
 CLICK TO ENABLE: أنقر للتشغيل
 Calibrate: معايرة
@@ -288,6 +290,7 @@ Custom execution limit: حد الاجراءات غير قياسي
 DHT11 Temperature & Humidity Sensor: مستشعر درجة الحرارة والرطوبة  DHT11
 DHT21 Temperature & Humidity Sensor: مستشعر درجة الحرارة والرطوبة  DHT21
 DHT22 Temperature & Humidity Sensor: مستشعر درجة الحرارة والرطوبة  DHT22
+Disabled due to failed executions: تم التعطيل بسبب عمليات التنفيذ الفاشلة
 DS18B20 Thermometer: ميزان الحرارة DS18B20
 Dark mode: الوضع المظلم
 Data: البيانات
@@ -820,6 +823,10 @@ Roller shutters: الأبجور
 Roof window opening sensor: مستشعر فتح نافذة السقف
 Roof window shutter operation: فتح نافذة السقف
 S/N: S/N
+Schedule disabled: تم تعطيل الجدول الزمني
+Schedule disabled due to failed executions: تعطيل الجدول الزمني بسبب عمليات التنفيذ الفاشلة
+Schedule ID: %scheduleId%: معرف الجدول الزمني: %scheduleId%
+Schedule name: %scheduleCaption%: اسم الجدول الزمني: %scheduleCaption%
 SUPLA - Account Activation: 'SUPLA:  تفعيل الحساب'
 SUPLA - Account Removal: SUPLA - حذف الحساب
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - إلغاء قفل جهاز لمثبت معتمد
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: 'SUPLA:  إخطار حول فشل تسجيل الدخول إلى %cloudHost%'
 SUPLA – new client app has been added to your account: SUPLA – تم تسجيل تطبيق عملاء جديد
 SUPLA – new device has been added to your account: SUPLA - تمت إضافة جهاز جديد إلى حسابك
+SUPLA – schedule disabled due to failed executions: SUPLA – تم تعطيل الجدول الزمني بسبب عمليات التنفيذ الفاشلة
 SUPLA – your device has been unlocked!: SUPLA - تم إلغاء قفل جهازك!
 SUPLA.ORG Team: فريق SUPLA.ORG
 Same as on master thermostat.: نفس الإعداد الموجود في ثرموستات الماستر.
@@ -1277,6 +1285,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: تم تسجيل سحابة SUPLA الخاصة بك تقريبًا.
 Your private SUPLA Cloud is not registered.: سحابة  SUPLA الخاصة غير مسجلة.
 Your scenes are allowed to have a maximum of {max} operations.: يُسمح أن تحتوي مشاهدك على ما يصل إلى {max} عمليات.
+Your schedule has been disabled automatically due to repeated failed executions.: تم تعطيل الجدول الزمني تلقائياً بسبب تكرار عمليات التنفيذ الفاشلة.
 Your schedules are allowed to have a maximum of {max} actions.: يُسمح أن تحتوي جداولك على ما يصل إلى {max} إجراءات.
 Your session has been expired.: انتهت جلستك.
 Your session is about to expire: سوف تنتهي جلستك بعد لحظة

--- a/translations/messages.az.yml
+++ b/translations/messages.az.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...temperaturanı izləyə bilərsiniz
 10 minutes before sunset, on day 10 of the month, May through August: Gün batımından 10 dəqiqə əvvəl, ayın 10-u, may–avqust aylarında
 15 minutes after sunrise, every 2 days: Gün doğuşundan 15 dəqiqə sonra, hər 2 gündə bir
+A confirmation that your schedule has been disabled automatically.: Cədvəlin avtomatik söndürüldüyünə dair təsdiq.
 A confirmation upon successful client app registration.: Yeni müştəri tətbiqinin uğurlu qeydiyyat təsdiqi.
 A confirmation upon successful device registration.: Cihazın uğurla qeydiyyat təsdiqi.
 A confirmation upon successful device unlocking.: Cihazın uğurla açılması təsdiqi.
@@ -179,6 +180,7 @@ Brightness level: Parlaqlıq səviyyəsi
 Button volume: Düymə səsi
 Buttons upside down: Düymələrin tərs yerləşməsi
 By signing in, you are authorizing {clientName} to control your devices.: Daxil olaraq {clientName} tətbiqinə cihazlarınızı idarə etməyə icazə verirsiniz.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Ətraflı məlumat üçün cədvəl tarixçəsinə baxın və problemi həll etdikdən sonra cədvəli yenidən aktivləşdirin.
 CLICK TO DISABLE: SÖNDÜRMƏK ÜÇÜN TIKLAYIN
 CLICK TO ENABLE: AKTİV ETMƏK ÜÇÜN TIKLAYIN
 Calibrate: Kalibrlə
@@ -326,6 +328,7 @@ Custom execution limit: Fərdi icra limiti
 DHT11 Temperature & Humidity Sensor: DHT11 Temperatur və Rütubət Sensoru
 DHT21 Temperature & Humidity Sensor: DHT21 Temperatur və Rütubət Sensoru
 DHT22 Temperature & Humidity Sensor: DHT22 Temperatur və Rütubət Sensoru
+Disabled due to failed executions: Uğursuz icralar səbəbindən söndürüldü
 DS18B20 Thermometer: DS18B20 Termometri
 Dark mode: Qaranlıq rejim
 Data: Məlumat
@@ -929,6 +932,10 @@ Roller shutters: Qatlanan pərdələr
 Roof window opening sensor: Dam pəncərəsi açılma sensoru
 Roof window shutter operation: Dam pəncərəsi əməliyyatı
 S/N: S/N
+Schedule disabled: Cədvəl söndürüldü
+Schedule disabled due to failed executions: Uğursuz icralar səbəbindən cədvəl söndürüldü
+Schedule ID: %scheduleId%: Cədvəl ID: %scheduleId%
+Schedule name: %scheduleCaption%: Cədvəl adı: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Hesabın aktivləşdirilməsi
 SUPLA - Account Removal: SUPLA - Hesabın silinməsi
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Sertifikatlı quraşdırıcılar üçün cihazın açılmasını təsdiqləyin
@@ -943,6 +950,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – %cloudHost%-də uğursuz giriş cəhdinin bildirişi
 SUPLA – new client app has been added to your account: SUPLA – Hesabınıza yeni müştəri tətbiqi əlavə edildi
 SUPLA – new device has been added to your account: SUPLA – Hesabınıza yeni cihaz əlavə edildi
+SUPLA – schedule disabled due to failed executions: SUPLA – cədvəl uğursuz icralar səbəbindən söndürüldü
 SUPLA – your device has been unlocked!: SUPLA – Cihazınız açıldı!
 SUPLA.ORG Team: SUPLA.ORG komandası
 Same as on master thermostat.: Əsas termostatla eyni
@@ -1452,6 +1460,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Şəxsi SUPLA Cloud instansiyanız demək olar ki, qeydiyyatdan keçib.
 Your private SUPLA Cloud is not registered.: Şəxsi SUPLA Cloud qeydiyyatdan keçməyib.
 Your scenes are allowed to have a maximum of {max} operations.: Sizin səhnələriniz maksimum {max} əməliyyat ola bilər.
+Your schedule has been disabled automatically due to repeated failed executions.: Cədvəliniz təkrarlanan uğursuz icralar səbəbindən avtomatik söndürüldü.
 Your schedules are allowed to have a maximum of {max} actions.: Sizin cədvəlləriniz maksimum {max} hərəkətə malik ola bilər.
 Your session has been expired.: Sessiyanızın müddəti bitib.
 Your session is about to expire: Sessiyanızın müddəti bitmək üzrədir

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...můžete sledovat teplotu
 10 minutes before sunset, on day 10 of the month, May through August: 10 minut před západem slunce, pouze 10. den v měsíci, od května do srpna
 15 minutes after sunrise, every 2 days: 15 minut po východu slunce, každý druhý den
+A confirmation that your schedule has been disabled automatically.: Potvrzení automatického vypnutí plánu.
 A confirmation upon successful client app registration.: Potvrzení registrace nové klientské aplikace.
 A confirmation upon successful device registration.: Potvrzení úspěšné registrace zařízení.
 A confirmation upon successful device unlocking.: Potvrzení odemčení zařízení.
@@ -158,6 +159,7 @@ Brightness level: Úroveň jasu
 Button volume: Hlasitost tlačítka
 Buttons upside down: Obrácené ovládání tlačítky
 By signing in, you are authorizing {clientName} to control your devices.: Přihlášením budeš aplikaci autorizovat {clientName} k ovládání vašich zařízení.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Podrobnosti najdete v historii plánu a plán znovu zapněte po odstranění problému.
 CLICK TO DISABLE: KLIKNI ABY VYPNOUT
 CLICK TO ENABLE: KLIKNI ABY ZAPNOUT
 Calibrate: Kalibrovat
@@ -288,6 +290,7 @@ Custom execution limit: Nestandardní počet provedení
 DHT11 Temperature & Humidity Sensor: Snímač teploty a vlhkosti DHT11
 DHT21 Temperature & Humidity Sensor: Snímač teploty a vlhkosti DHT21
 DHT22 Temperature & Humidity Sensor: Snímač teploty a vlhkosti DHT22
+Disabled due to failed executions: Vypnuto kvůli neúspěšným vykonáním
 DS18B20 Thermometer: Teploměr DS18B20
 Dark mode: Tmavý režim
 Data: Údaje
@@ -820,6 +823,10 @@ Roller shutters: Rolety
 Roof window opening sensor: Senzor otevření střešního okna
 Roof window shutter operation: Otevírání střešního okna
 S/N: S/N
+Schedule disabled: Plán vypnut
+Schedule disabled due to failed executions: Vypnutí plánu kvůli neúspěšným vykonáním
+Schedule ID: %scheduleId%: Identifikátor plánu: %scheduleId%
+Schedule name: %scheduleCaption%: Název plánu: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Aktivace účtu
 SUPLA - Account Removal: SUPLA – Odstranění účtu
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Odblokování zařízení pro certifikovaného instalatéra
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA - upozornění na neúspěšné přihlášení na %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - byla zaregistrována nová klientská aplikace
 SUPLA – new device has been added to your account: SUPLA – do vašeho účtu bylo přidáno nové zařízení
+SUPLA – schedule disabled due to failed executions: SUPLA – plán vypnut kvůli neúspěšným vykonáním
 SUPLA – your device has been unlocked!: SUPLA - Vaše zařízení bylo odemčeno!
 SUPLA.ORG Team: Tým SUPLA.ORG
 Same as on master thermostat.: Stejné nastavení jako na hlavním termostatu.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Váš soukromý cloud SUPLA je téměř registrován.
 Your private SUPLA Cloud is not registered.: Váš soukromý cloud SUPLA není registrován.
 Your scenes are allowed to have a maximum of {max} operations.: Vaše scény mohou mít maximálně {max} operací.
+Your schedule has been disabled automatically due to repeated failed executions.: Váš plán byl automaticky vypnut kvůli opakovaným neúspěšným vykonáním.
 Your schedules are allowed to have a maximum of {max} actions.: Vaše plány mohou mít maximálně {max} akcí.
 Your session has been expired.: Vaše relace vypršela.
 Your session is about to expire: Vaše relace brzy vyprší

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...du kannst die Temperatur überwachen
 10 minutes before sunset, on day 10 of the month, May through August: 10 Minuten vor dem Sonnenuntergang, nur am 10. Monatstag, von Mai bis August
 15 minutes after sunrise, every 2 days: 15 Minuten nach dem Sonnenaufgang, jeden zweiten Tag
+A confirmation that your schedule has been disabled automatically.: Bestätigung der automatischen Deaktivierung des Harmonogramms.
 A confirmation upon successful client app registration.: Registrierungsbestätigung der neuen Client-Anwendung.
 A confirmation upon successful device registration.: Bestätigung der erfolgreichen Geräteregistrierung.
 A confirmation upon successful device unlocking.: Bestätigung der Gerätefreigabe.
@@ -158,6 +159,7 @@ Brightness level: Helligkeitsstufe
 Button volume: Tastentonlautstärke
 Buttons upside down: Umgekehrte Tastensteuerung
 By signing in, you are authorizing {clientName} to control your devices.: Wenn Sie sich einloggen, ermächtigen Sie die Anwendung {clientName}, Ihre Geräte zu steuern.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Prüfen Sie den Harmonogramm-Verlauf auf Details und aktivieren Sie das Harmonogramm nach Behebung des Problems erneut.
 CLICK TO DISABLE: KLICKEN UM AUSZUSCHALTEN
 CLICK TO ENABLE: KLICKEN UM EINZUSCHALTEN
 Calibrate: Kalibrieren
@@ -288,6 +290,7 @@ Custom execution limit: Benutzerdefinierter Ausführungslimit
 DHT11 Temperature & Humidity Sensor: DHT11 Temperatur- und Feuchtigkeitssensor
 DHT21 Temperature & Humidity Sensor: DHT21 Temperatur- und Feuchtigkeitssensor
 DHT22 Temperature & Humidity Sensor: DHT22 Temperatur- und Feuchtigkeitssensor
+Disabled due to failed executions: Aufgrund fehlgeschlagener Ausführungen deaktiviert
 DS18B20 Thermometer: DS18B20 Thermometer
 Dark mode: Dunkelmodus
 Data: Daten
@@ -820,6 +823,10 @@ Roller shutters: Rolladen
 Roof window opening sensor: Dachfenster-Öffnungssensor
 Roof window shutter operation: Öffnen des Dachfensters
 S/N: Seriennummer
+Schedule disabled: Harmonogramm deaktiviert
+Schedule disabled due to failed executions: Harmonogramm aufgrund fehlgeschlagener Ausführungen deaktiviert
+Schedule ID: %scheduleId%: Kennung des Harmonogramms: %scheduleId%
+Schedule name: %scheduleCaption%: Name des Harmonogramms: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Kontoaktivierung
 SUPLA - Account Removal: SUPLA – Löschen des Accounts
 SUPLA - Confirm unlocking device for authorized installers: SUPLA – Freischaltung eines Geräts für zertifizierte Installateure
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Benachrichtigung über fehlgeschlagene Anmeldung bei %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - neue Client-App wurde registriert
 SUPLA – new device has been added to your account: SUPLA - ein neues Gerät wurde zu Ihrem Konto hinzugefügt
+SUPLA – schedule disabled due to failed executions: SUPLA – Harmonogramm aufgrund fehlgeschlagener Ausführungen deaktiviert
 SUPLA – your device has been unlocked!: SUPLA – Ihr Gerät ist jetzt freigeschaltet!
 SUPLA.ORG Team: Team SUPLA.ORG
 Same as on master thermostat.: Einstellung wie beim übergeordneten Thermostat.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Ihre private SUPLA-Cloud ist fast registriert.
 Your private SUPLA Cloud is not registered.: Ihre private SUPLA-Cloud ist nicht registriert
 Your scenes are allowed to have a maximum of {max} operations.: Ihre Szenen dürfen maximal {max} Vorgänge haben.
+Your schedule has been disabled automatically due to repeated failed executions.: Ihr Harmonogramm wurde aufgrund wiederholter fehlgeschlagener Ausführungen automatisch deaktiviert.
 Your schedules are allowed to have a maximum of {max} actions.: Ihre Zeitpläne dürfen maximal {max} Aktionen haben.
 Your session has been expired.: Deine Sitzung ist abgelaufen.
 Your session is about to expire: Deine Sitzung wird in kürze ablaufen

--- a/translations/messages.el.yml
+++ b/translations/messages.el.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...μπορείτε να παρακολουθείτε τη θερμοκρασία
 10 minutes before sunset, on day 10 of the month, May through August: 10 λεπτά πριν από τη δύση του ηλίου, μόνο τη 10η ημέρα του μήνα, από Μάιο έως Αύγουστο
 15 minutes after sunrise, every 2 days: 15 λεπτά μετά την ανατολή του ηλίου, κάθε δεύτερη μέρα
+A confirmation that your schedule has been disabled automatically.: Επιβεβαίωση αυτόματης απενεργοποίησης του χρονοδιαγράμματος.
 A confirmation upon successful client app registration.: Επιβεβαίωση εγγραφής της νέας εφαρμογής πελάτη.
 A confirmation upon successful device registration.: Επιβεβαιώστε ότι η συσκευή έχει εγγραφεί με επιτυχία.
 A confirmation upon successful device unlocking.: Επιβεβαίωση ξεκλειδώματος συσκευής.
@@ -158,6 +159,7 @@ Brightness level: Επίπεδο φωτεινότητας
 Button volume: Ένταση κουμπιού
 Buttons upside down: Αντίστροφος έλεγχος κουμιών
 By signing in, you are authorizing {clientName} to control your devices.: Με τη σύνδεση, δίνετε την εξουσιοδότηση στην εφαρμογή {clientName} να ελέγχει τις συσκευές σας.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Ελέγξτε το ιστορικό του χρονοδιαγράμματος για λεπτομέρειες και ενεργοποιήστε το ξανά αφού διορθώσετε το πρόβλημα.
 CLICK TO DISABLE: ΚΑΝΤΕ ΚΛΙΚ ΓΙΑ ΝΑ ΚΛΕΙΣΕΤΕ
 CLICK TO ENABLE: ΚΑΝΤΕ ΚΛΙΚ ΓΙΑ ΝΑ ΕΝΕΡΓΟΠΟΙΗΣΕΤΕ
 Calibrate: Βαθμονόμηση
@@ -288,6 +290,7 @@ Custom execution limit: Προσαρμοσμένο όριο εκτελέσεων
 DHT11 Temperature & Humidity Sensor: Αισθητήρας θερμοκρασίας και υγρασίας DHT11
 DHT21 Temperature & Humidity Sensor: Αισθητήρας θερμοκρασίας και υγρασίας DHT21
 DHT22 Temperature & Humidity Sensor: Αισθητήρας θερμοκρασίας και υγρασίας DHT22
+Disabled due to failed executions: Απενεργοποιήθηκε λόγω αποτυχημένων εκτελέσεων
 DS18B20 Thermometer: Θερμόμετρο DS18B20
 Dark mode: Σκοτεινή λειτουργία
 Data: Δεδομένα
@@ -820,6 +823,10 @@ Roller shutters: Περσίδες
 Roof window opening sensor: Αισθητήρας ανοίγματος παραθύρου οροφής
 Roof window shutter operation: Άνοιγμα παραθύρου οροφής
 S/N: S/N
+Schedule disabled: Το χρονοδιάγραμμα απενεργοποιήθηκε
+Schedule disabled due to failed executions: Απενεργοποίηση χρονοδιαγράμματος λόγω αποτυχημένων εκτελέσεων
+Schedule ID: %scheduleId%: Αναγνωριστικό χρονοδιαγράμματος: %scheduleId%
+Schedule name: %scheduleCaption%: Όνομα χρονοδιαγράμματος: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Ενεργοποίηση λογαριασμού
 SUPLA - Account Removal: SUPLA - Διαγραφή λογαριασμού
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Ξεκλείδωμα συσκευής που προορίζεται για πιστοποιημένο εγκαταστάτη
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA - Ειδοποίηση για αποτυχημένη σύνδεση στο %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - μια νέα εφαρμογή πελάτη έχει καταχωρηθεί
 SUPLA – new device has been added to your account: SUPLA - μια νέα συσκευή έχει προστεθεί στο λογαριασμό σας
+SUPLA – schedule disabled due to failed executions: SUPLA – το χρονοδιάγραμμα απενεργοποιήθηκε λόγω αποτυχημένων εκτελέσεων
 SUPLA – your device has been unlocked!: SUPLA - Η συσκευή σας έχει ξεκλειδωθεί!
 SUPLA.ORG Team: Η ομάδα SUPLA.ORG
 Same as on master thermostat.: Ίδια ρύθμιση με αυτή του κύριου θερμοστάτη.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Το ιδιωτικό σας SUPLA cloud είναι σχεδόν εγγεγραμμένο.
 Your private SUPLA Cloud is not registered.: Το ιδιωτικό σας SUPLA cloud δεν είναι εγγεγραμμένο.
 Your scenes are allowed to have a maximum of {max} operations.: Οι σκηνές σας μπορεί να έχουν έως και {max} ενέργειες.
+Your schedule has been disabled automatically due to repeated failed executions.: Το χρονοδιάγραμμά σας απενεργοποιήθηκε αυτόματα λόγω επαναλαμβανόμενων αποτυχημένων εκτελέσεων.
 Your schedules are allowed to have a maximum of {max} actions.: Τα χρονοδιαγράμματά σας μπορούν να έχουν το πολύ {max} κοινόχρηστα στοιχεία.
 Your session has been expired.: Η συνεδρία σας έχει λήξει.
 Your session is about to expire: Η συνεδρία σας θα λήξει σε λίγο

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...puedes controlar la temperatura
 10 minutes before sunset, on day 10 of the month, May through August: 10 minutos antes del atardecer, solo el día 10 del mes, de mayo a agosto
 15 minutes after sunrise, every 2 days: 15 minutos después del amanecer, cada dos días
+A confirmation that your schedule has been disabled automatically.: Confirmación de la desactivación automática del horario.
 A confirmation upon successful client app registration.: Confirmación de registro de una nueva aplicación cliente.
 A confirmation upon successful device registration.: Confirmación de registro exitoso del dispositivo.
 A confirmation upon successful device unlocking.: Confirmación del desbloqueo del dispositivo.
@@ -158,6 +159,7 @@ Brightness level: Nivel de la luminosidad
 Button volume: Volumen del botón
 Buttons upside down: Control del botón de marcha atrás
 By signing in, you are authorizing {clientName} to control your devices.: Al iniciar sesión, autorizas a la aplicación {clientName} a controlar tus dispositivos.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Consulte el historial del horario para más detalles y vuelva a activarlo después de solucionar el problema.
 CLICK TO DISABLE: HAZ CLIC PARA DESACTIVAR
 CLICK TO ENABLE: HAZ CLIC PARA ACTIVAR
 Calibrate: Calibrar
@@ -288,6 +290,7 @@ Custom execution limit: Límite de acciones personalizado
 DHT11 Temperature & Humidity Sensor: Sensor de temperatura y humedad DHT11
 DHT21 Temperature & Humidity Sensor: Sensor de temperatura y humedad DHT21
 DHT22 Temperature & Humidity Sensor: Sensor de temperatura y humedad DHT22
+Disabled due to failed executions: Desactivado por ejecuciones fallidas
 DS18B20 Thermometer: Termómetro DS18B20
 Dark mode: Modo oscuro
 Data: Datos
@@ -820,6 +823,10 @@ Roller shutters: Persianas
 Roof window opening sensor: Sensor de apertura del techo solar
 Roof window shutter operation: Apertura del techo corredizo
 S/N: S/N
+Schedule disabled: Horario desactivado
+Schedule disabled due to failed executions: Horario desactivado por ejecuciones fallidas
+Schedule ID: %scheduleId%: ID del horario: %scheduleId%
+Schedule name: %scheduleCaption%: Nombre del horario: %scheduleCaption%
 SUPLA - Account Activation: SUPLA – Activación de la cuenta
 SUPLA - Account Removal: SUPLA - Eliminación de la cuenta
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Desbloqueo del dispositivo destinado a un instalador certificado
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: 'SUPLA: Aviso del error de acceso a la cuenta de %cloudHost%'
 SUPLA – new client app has been added to your account: SUPLA - registrada una nueva aplicación cliente
 SUPLA – new device has been added to your account: 'SUPLA: se ha agregado un nuevo dispositivo a tu cuenta'
+SUPLA – schedule disabled due to failed executions: SUPLA – horario desactivado por ejecuciones fallidas
 SUPLA – your device has been unlocked!: SUPLA - ¡Tu dispositivo ha sido desbloqueado!
 SUPLA.ORG Team: Grupo SUPLA.ORG
 Same as on master thermostat.: El ajuste es el mismo que en el termostato principal.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Tu nube privada SUPLA está casi registrada.
 Your private SUPLA Cloud is not registered.: Tu nube privada SUPLA no está registrada.
 Your scenes are allowed to have a maximum of {max} operations.: Tus escenas pueden tener un máximo de {max} operaciones.
+Your schedule has been disabled automatically due to repeated failed executions.: Su horario se ha desactivado automáticamente debido a ejecuciones fallidas repetidas.
 Your schedules are allowed to have a maximum of {max} actions.: Tus programaciones pueden tener un máximo de {max} acciones.
 Your session has been expired.: Tu sesión ha expirado.
 Your session is about to expire: Tu sesión está a punto de caducar

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...vous pouvez suivre la température
 10 minutes before sunset, on day 10 of the month, May through August: 10 minutes avant le coucher du soleil, uniquement le 10 du mois, de mai à août
 15 minutes after sunrise, every 2 days: 15 minutes après le lever du soleil, tous les deux jours
+A confirmation that your schedule has been disabled automatically.: Confirmation de la désactivation automatique du calendrier de prog.
 A confirmation upon successful client app registration.: Confirmation de l’enregistrement de la nouvelle application cliente.
 A confirmation upon successful device registration.: Confirmation de l’enregistrement réussi de l’appareil.
 A confirmation upon successful device unlocking.: Confirmation du déverrouillage de l’appareil.
@@ -158,6 +159,7 @@ Brightness level: Niveau de luminosité
 Button volume: Volume du bouton
 Buttons upside down: Commande des boutons inversée
 By signing in, you are authorizing {clientName} to control your devices.: En vous connectant, vous autorisez l’application {clientName} à contrôler vos appareils.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Consultez l'historique du calendrier de prog. pour plus de détails et réactivez-le après avoir corrigé le problème.
 CLICK TO DISABLE: CLIQUER ICI POUR DÉSACTIVER
 CLICK TO ENABLE: CLIQUER ICI POUR ACTIVER
 Calibrate: Étalonner
@@ -288,6 +290,7 @@ Custom execution limit: Limite des exécutions non standard
 DHT11 Temperature & Humidity Sensor: Capteur de température et d'humidité DHT11
 DHT21 Temperature & Humidity Sensor: Capteur de température et d'humidité DHT21
 DHT22 Temperature & Humidity Sensor: Capteur de température et d'humidité DHT22
+Disabled due to failed executions: Désactivé en raison d'exécutions échouées
 DS18B20 Thermometer: Termometr DS18B20
 Dark mode: Mode sombre
 Data: Données
@@ -820,6 +823,10 @@ Roller shutters: Volets roulants
 Roof window opening sensor: Capteur d’ouverture de toit ouvrant
 Roof window shutter operation: Ouverture du toit ouvrant
 S/N: S/N
+Schedule disabled: Calendrier de prog. désactivé
+Schedule disabled due to failed executions: Calendrier de prog. désactivé en raison d'exécutions échouées
+Schedule ID: %scheduleId%: Identifiant du calendrier de prog. : %scheduleId%
+Schedule name: %scheduleCaption%: Nom du calendrier de prog. : %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Activation de votre compte
 SUPLA - Account Removal: SUPLA - Suppression de compte
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Déverrouillage de l’appareil réservé à l’installateur certifié
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Notification d'échec de connexion à %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - une nouvelle application client a été enregistrée
 SUPLA – new device has been added to your account: SUPLA - un nouvel appareil a été ajouté à votre compte
+SUPLA – schedule disabled due to failed executions: SUPLA – calendrier de prog. désactivé en raison d'exécutions échouées
 SUPLA – your device has been unlocked!: SUPLA - Votre appareil a été déverrouillé !
 SUPLA.ORG Team: Équipe SUPLA.ORG
 Same as on master thermostat.: Réglage identique à celui du thermostat principal.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Votre nuage SUPLA privé est presque enregistré.
 Your private SUPLA Cloud is not registered.: Votre cloud personnel SUPLA n'est pas enregistré.
 Your scenes are allowed to have a maximum of {max} operations.: Vos scènes peuvent avoir un maximum de {max} opérations.
+Your schedule has been disabled automatically due to repeated failed executions.: Votre calendrier de prog. a été désactivé automatiquement en raison d'exécutions échouées répétées.
 Your schedules are allowed to have a maximum of {max} actions.: Vos calendriers peuvent avoir un maximum de {max} actions.
 Your session has been expired.: Votre session a expiré.
 Your session is about to expire: Votre session est sur le point d'expirer

--- a/translations/messages.hu.yml
+++ b/translations/messages.hu.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ... megfigyelheti a hőmérsékletet
 10 minutes before sunset, on day 10 of the month, May through August: 10 perccel napnyugta előtt, májustól augusztusig csak a hónap 10. napján
 15 minutes after sunrise, every 2 days: 15 perccel napfelkelte után, minden második nap
+A confirmation that your schedule has been disabled automatically.: Az ütemterv automatikus kikapcsolásának megerősítése.
 A confirmation upon successful client app registration.: Az új ügyfélalkalmazás regisztrációjának megerősítése.
 A confirmation upon successful device registration.: A készülék sikeres regisztrációjának megerősítése.
 A confirmation upon successful device unlocking.: A készülék feloldásának megerősítése.
@@ -158,6 +159,7 @@ Brightness level: Fényerőszint
 Button volume: Kapcsológomb hangerő
 Buttons upside down: Fordított vezérlés kapcsológombokkal
 By signing in, you are authorizing {clientName} to control your devices.: A bejelentkezéssel Ön engedélyezi a {clientName} alkalmazásnak, hogy irányítsa az eszközeit.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: A részletekért ellenőrizze az ütemterv előzményeit, és a probléma megoldása után kapcsolja be újra az ütemtervet.
 CLICK TO DISABLE: KATTINTSON KIKAPCSOLÁSHOZ
 CLICK TO ENABLE: KATTINTSON A BEKAPCSOLÁSHOZ
 Calibrate: Kalibrálás
@@ -288,6 +290,7 @@ Custom execution limit: Szokásostól eltérú teljesítménykorlát
 DHT11 Temperature & Humidity Sensor: DHT 11 hőmérséklet- és páratartalom-érzékelő
 DHT21 Temperature & Humidity Sensor: DHT21 hőmérséklet- és páratartalom-érzékelő
 DHT22 Temperature & Humidity Sensor: DHT22  hőmérséklet- és páratartalom-érzékelő
+Disabled due to failed executions: Sikertelen végrehajtások miatt kikapcsolva
 DS18B20 Thermometer: DS18B20 hőmérő
 Dark mode: Sötét üzemmód
 Data: Adatok
@@ -820,6 +823,10 @@ Roller shutters: Redőnyök
 Roof window opening sensor: A tetőablak nyitás érzékelő
 Roof window shutter operation: A tetőablak nyitása
 S/N: S/N (sorozat szám)
+Schedule disabled: Ütemterv kikapcsolva
+Schedule disabled due to failed executions: Ütemterv kikapcsolása sikertelen végrehajtások miatt
+Schedule ID: %scheduleId%: Ütemterv azonosító: %scheduleId%
+Schedule name: %scheduleCaption%: Ütemterv neve: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Fiók aktiválása
 SUPLA - Account Removal: SUPLA - Fiók törlése
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Készülék feloldása hivatalos tanúsítvánnyal rendelkező telepítő által engedélyezett
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA - Értesítés a %cloudHost% oldalra történő sikertelen bejelentkezésről
 SUPLA – new client app has been added to your account: SUPLA – új ügyfélalkalmazás regisztrálva
 SUPLA – new device has been added to your account: SUPLA - új eszköz hozzáadva a fiókjához
+SUPLA – schedule disabled due to failed executions: SUPLA – ütemterv kikapcsolva sikertelen végrehajtások miatt
 SUPLA – your device has been unlocked!: SUPLA - A készüléke feloldva!
 SUPLA.ORG Team: A SUPLA.ORG Csapata
 Same as on master thermostat.: A beállítás megegyezik a főtermosztáton lévő beállításokkal.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: A saját SUPLA felhője majdnem regisztrált.
 Your private SUPLA Cloud is not registered.: A saját SUPLA felhője nincs regisztrálva.
 Your scenes are allowed to have a maximum of {max} operations.: 'Jelenetein legfeljebb {max} művelet hajtható végre. '
+Your schedule has been disabled automatically due to repeated failed executions.: Az ütemterv automatikusan kikapcsolásra került az ismételt sikertelen végrehajtások miatt.
 Your schedules are allowed to have a maximum of {max} actions.: Az Ön ütemterve maximum {max} műveletet tartalmazhat.
 Your session has been expired.: Twoja sesja wygasła.
 Your session is about to expire: A munkamenete hamarosan lejár

--- a/translations/messages.it.yml
+++ b/translations/messages.it.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...puoi monitorare la temperatura
 10 minutes before sunset, on day 10 of the month, May through August: 10’ prima del tramonto, il giorno 10 del mese, da Maggio ad Agosto
 15 minutes after sunrise, every 2 days: 15’ dopo l’alba, ogni 2 giorni
+A confirmation that your schedule has been disabled automatically.: Conferma della disattivazione automatica dello scadenzario.
 A confirmation upon successful client app registration.: Conferma dopo registrazione app avvenuta con successo
 A confirmation upon successful device registration.: conferma dopo registrazione dispositivo avvenuta con successo
 A new client app (smartphone) been added to your SUPLA-Cloud account.: Una nuova app (smartphone) è stata aggiunta al tuo account SUPLA-Cloud
@@ -151,6 +152,7 @@ Brightness adjustment for automatic mode: Impostazione luminosità per modo auto
 Brightness level: Livello luminosità
 Button volume: Volume pulsanti
 By signing in, you are authorizing {clientName} to control your devices.: Accedendo, stai autorizzando l'applicazione {clientName} a controllare i tuoi dispositivi.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Controlla la cronologia dello scadenzario per i dettagli e riattivalo dopo aver risolto il problema.
 CLICK TO DISABLE: CLICCA PER DISABILITARE
 CLICK TO ENABLE: CLICCA PER ABILITARE
 Calibrate: Calibrare
@@ -262,6 +264,7 @@ Custom execution limit: Limite delle esecuzioni non standard
 DHT11 Temperature & Humidity Sensor: Termometro di temperatura e umidità DHT11
 DHT21 Temperature & Humidity Sensor: Termometro di temperatura e umidità DHT21
 DHT22 Temperature & Humidity Sensor: Termometro di temperatura e umidità DHT22
+Disabled due to failed executions: Disattivato a causa di esecuzioni fallite
 DS18B20 Thermometer: Termometro DS18B20
 Dark mode: Modalità Scuro
 Data: Dati
@@ -757,6 +760,10 @@ Roller shutters: Avvolgibili
 Roof window opening sensor: Sensore apertura lucernario
 Roof window shutter operation: Funzionamento lucernario
 S/N: S/N
+Schedule disabled: Scadenzario disattivato
+Schedule disabled due to failed executions: Scadenzario disattivato a causa di esecuzioni fallite
+Schedule ID: %scheduleId%: ID scadenzario: %scheduleId%
+Schedule name: %scheduleCaption%: Nome scadenzario: %scheduleCaption%
 SUPLA - Account Activation: SUPLA – Attivazione dell’account
 SUPLA - Account Removal: SUPLA – Cancellazione dell’account
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Conferma sblocco dispositivi per installatori autorizzati
@@ -770,6 +777,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Notifica di accesso al %cloudHost% non riuscito
 SUPLA – new client app has been added to your account: SUPLA - nuova app aggiunta al tuo account
 SUPLA – new device has been added to your account: SUPLA - nuovo dispositivo aggiunto al tuo account
+SUPLA – schedule disabled due to failed executions: SUPLA – scadenzario disattivato a causa di esecuzioni fallite
 SUPLA – your device has been unlocked!: SUPLA - il tuo dispositivo è stato sbloccato!
 SUPLA.ORG Team: Squadra di SUPLA.ORG
 Saturdays: Sabato
@@ -1186,6 +1194,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: La Tua nuvola privata SUPLA è quasi registrata.
 Your private SUPLA Cloud is not registered.: Il tuo cloud privato SUPLA non è registrato.
 Your scenes are allowed to have a maximum of {max} operations.: E’ possibile inserire negli scenari un massimo di {max} azioni
+Your schedule has been disabled automatically due to repeated failed executions.: Il tuo scadenzario è stato disattivato automaticamente a causa di ripetute esecuzioni fallite.
 Your schedules are allowed to have a maximum of {max} actions.: I tuoi scadenzari possono eseguire massimo {max} azioni.
 Your session has been expired.: La Tua sessione è scaduta.
 Your session is about to expire: La tua sessione sta per scadere

--- a/translations/messages.lt.yml
+++ b/translations/messages.lt.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...galite stebėti temperatūrą
 10 minutes before sunset, on day 10 of the month, May through August: 10 minučių iki saulėlydžio, tik mėnesio 10 dieną, nuo gegužės iki rugpjūčio
 15 minutes after sunrise, every 2 days: 15 minučių po saulėtekio, kas antrą dieną
+A confirmation that your schedule has been disabled automatically.: Patvirtinimas, kad tvarkaraštis buvo automatiškai išjungtas.
 A confirmation upon successful client app registration.: Naujos kliento programos registracijos patvirtinimas.
 A confirmation upon successful device registration.: Sėkmingos įrenginio registracijos patvirtinimas.
 A confirmation upon successful device unlocking.: Įrenginio atrakinimo patvirtinimas.
@@ -158,6 +159,7 @@ Brightness level: Ryškumo lygis
 Button volume: Mygtuko garsumas
 Buttons upside down: Atvirkštinis valdymas mygtukais
 By signing in, you are authorizing {clientName} to control your devices.: Prisijungdami įgaliojate {clientName} valdyti Jūsų įrenginius.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Norėdami sužinoti daugiau, patikrinkite tvarkaraščio istoriją ir įjunkite jį iš naujo išsprendę problemą.
 CLICK TO DISABLE: SPUSTELĖKITE, KAD IŠJUNGTI
 CLICK TO ENABLE: SPUSTELĖKITE, KAD ĮJUNGTI
 Calibrate: Kalibruoti
@@ -288,6 +290,7 @@ Custom execution limit: Nestandartinis atlikimų limitas
 DHT11 Temperature & Humidity Sensor: Temperatūros ir drėgmės jutiklis DHT11
 DHT21 Temperature & Humidity Sensor: Temperatūros ir drėgmės jutiklis DHT21
 DHT22 Temperature & Humidity Sensor: Temperatūros ir drėgmės jutiklis DHT22
+Disabled due to failed executions: Išjungta dėl nepavykusių vykdymų
 DS18B20 Thermometer: Termometras DS18B20
 Dark mode: Tamsus režimas
 Data: Duomenys
@@ -820,6 +823,10 @@ Roller shutters: Žaliuzės
 Roof window opening sensor: Stoglangio atidarymo jutiklis
 Roof window shutter operation: Stoglangio atidarymas
 S/N: S/N
+Schedule disabled: Tvarkaraštis išjungtas
+Schedule disabled due to failed executions: Tvarkaraščio išjungimas dėl nepavykusių vykdymų
+Schedule ID: %scheduleId%: Tvarkaraščio identifikatorius: %scheduleId%
+Schedule name: %scheduleCaption%: Tvarkaraščio pavadinimas: %scheduleCaption%
 SUPLA - Account Activation: SUPLA – Paskyros aktyvavimas
 SUPLA - Account Removal: SUPLA – Paskyros šalinimas
 SUPLA - Confirm unlocking device for authorized installers: SUPLA – Įrenginio, skirto sertifikuotam montuotojui, atrakinimas
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Pranešimas apie nesėkmingą prisijungimą prie %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA – užregistruota nauja kliento programa
 SUPLA – new device has been added to your account: SUPLA – naujas įrenginys pridėtas prie Jūsų paskyros
+SUPLA – schedule disabled due to failed executions: SUPLA – tvarkaraštis išjungtas dėl nepavykusių vykdymų
 SUPLA – your device has been unlocked!: SUPLA – Jūsų įrenginys atrakintas!
 SUPLA.ORG Team: SUPLA.ORG komanda
 Same as on master thermostat.: Nustatymas toks pat kaip ir pagrindiniame termostate.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Jūsų privatus debesis SUPLA yra beveik užregistruotas.
 Your private SUPLA Cloud is not registered.: Jūsu privātais mākonis SUPLA nav reģistrēts.
 Your scenes are allowed to have a maximum of {max} operations.: Jūsų scenose gali būti daugiausiai {max} operacijų.
+Your schedule has been disabled automatically due to repeated failed executions.: Jūsų tvarkaraštis buvo automatiškai išjungtas dėl pakartotinių nepavykusių vykdymų.
 Your schedules are allowed to have a maximum of {max} actions.: Jūsų tvarkaraščiuose gali būti daugiausiai {max} veiksmų.
 Your session has been expired.: Jūsų sesija baigėsi.
 Your session is about to expire: Jūsų sesija baigsis.

--- a/translations/messages.nb.yml
+++ b/translations/messages.nb.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...kontrollere temperaturen
 10 minutes before sunset, on day 10 of the month, May through August: 10 minutter før solnedgang, kun på den 10. dagen i måneden, fra mai til august
 15 minutes after sunrise, every 2 days: 15 minutter etter soloppgang, annenhver dag
+A confirmation that your schedule has been disabled automatically.: Bekreftelse på at planen ble automatisk deaktivert.
 A confirmation upon successful client app registration.: Bekreftelse på registrering av ny klientapplikasjon.
 A confirmation upon successful device registration.: Bekreftelse på vellykket enhetsregistrering.
 A confirmation upon successful device unlocking.: Bekreftelse på opplåsing av enheten.
@@ -158,6 +159,7 @@ Brightness level: Lysstyrkenivå
 Button volume: Volum på knappene
 Buttons upside down: Invertert knappestyring
 By signing in, you are authorizing {clientName} to control your devices.: Ved å logge på tillater du {clientName}-applikasjonen til å kontrollere innretningene dine.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Sjekk planhistorikken for detaljer og aktiver planen på nytt etter at problemet er løst.
 CLICK TO DISABLE: TRYKK FOR Å SKRU AV
 CLICK TO ENABLE: TRYKK FOR Å SKRU PÅ
 Calibrate: Kalibrer
@@ -288,6 +290,7 @@ Custom execution limit: Tilpasset grense på utførelser
 DHT11 Temperature & Humidity Sensor: Temperatur- og fuktighetssensor DHT11
 DHT21 Temperature & Humidity Sensor: Temperatur- og fuktighetssensor DHT21
 DHT22 Temperature & Humidity Sensor: Temperatur- og fuktighetssensor DHT22
+Disabled due to failed executions: Deaktivert på grunn av mislykkede kjøringer
 DS18B20 Thermometer: Termometer DS18B20
 Dark mode: Mørk modus
 Data: Data
@@ -820,6 +823,10 @@ Roller shutters: Rullegardiner
 Roof window opening sensor: Sensor for åpning av takvindu
 Roof window shutter operation: Åpning av takvindu
 S/N: S/N
+Schedule disabled: Plan deaktivert
+Schedule disabled due to failed executions: Plan deaktivert på grunn av mislykkede kjøringer
+Schedule ID: %scheduleId%: Plan-ID: %scheduleId%
+Schedule name: %scheduleCaption%: Plannavn: %scheduleCaption%
 SUPLA - Account Activation: SUPLA – Aktivering av konto
 SUPLA - Account Removal: SUPLA – Fjerning av konto
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Låser opp en enhet som er beregnet til en sertifisert installatør
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – beskjed om mislykket innlogging til %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - en ny klientapplikasjon er registrert
 SUPLA – new device has been added to your account: SUPLA - en ny enhet er lagt til kontoen din
+SUPLA – schedule disabled due to failed executions: SUPLA – plan deaktivert på grunn av mislykkede kjøringer
 SUPLA – your device has been unlocked!: SUPLA - Enheten din har blitt låst opp!
 SUPLA.ORG Team: SUPLA.ORG Team
 Same as on master thermostat.: Innstillingen er den samme som på hovedtermostaten.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Din privat SUPLA cloud er nesten registrert.
 Your private SUPLA Cloud is not registered.: Din privat SUPLA cloud er ikke registrert.
 Your scenes are allowed to have a maximum of {max} operations.: Dine scener kan ha maksimalt {max} operasjoner.
+Your schedule has been disabled automatically due to repeated failed executions.: Planen din ble automatisk deaktivert på grunn av gjentatte mislykkede kjøringer.
 Your schedules are allowed to have a maximum of {max} actions.: Dine ruter kan ha maksimalt {max} aksjoner.
 Your session has been expired.: Din sesjon er over.
 Your session is about to expire: Din sesjon er snart over.

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...u kunt de temperatuur volgen
 10 minutes before sunset, on day 10 of the month, May through August: 10 minuten voor zonsondergang, alleen op de 10e van de maand, van mei tot augustus
 15 minutes after sunrise, every 2 days: 15 minuten na zonsopgang, om de andere dag
+A confirmation that your schedule has been disabled automatically.: Bevestiging dat het schema automatisch is uitgeschakeld.
 A confirmation upon successful client app registration.: Bevestiging van de registratie van de nieuwe cliëntapplicatie.
 A confirmation upon successful device registration.: Bevestiging van succesvolle apparaatregistratie.
 A confirmation upon successful device unlocking.: Bevestiging van ontgrendeling van toestel.
@@ -158,6 +159,7 @@ Brightness level: Helderheidsniveau
 Button volume: Volume knop
 Buttons upside down: Omgekeerde knopbediening
 By signing in, you are authorizing {clientName} to control your devices.: Door in te loggen, machtig je de {clientName}-applicatie om je apparaten te bedienen.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Bekijk de schemageschiedenis voor details en schakel het schema opnieuw in nadat het probleem is opgelost.
 CLICK TO DISABLE: KLIK OM UIT TE ZETTEN
 CLICK TO ENABLE: KLIK OM IN TE SCHAKELEN
 Calibrate: Kalibreer
@@ -288,6 +290,7 @@ Custom execution limit: Afwijkend prestatielimiet
 DHT11 Temperature & Humidity Sensor: DHT11 temperatuur- en vochtigheidssensor
 DHT21 Temperature & Humidity Sensor: DHT21 temperatuur- en vochtigheidssensor
 DHT22 Temperature & Humidity Sensor: DHT12 temperatuur- en vochtigheidssensor
+Disabled due to failed executions: Uitgeschakeld vanwege mislukte uitvoeringen
 DS18B20 Thermometer: DS18B20-thermometer
 Dark mode: Donkere modus
 Data: Details
@@ -820,6 +823,10 @@ Roller shutters: Rolluiken
 Roof window opening sensor: Openingssensor dakvenster
 Roof window shutter operation: Openen van het dakvenster
 S/N: S/N
+Schedule disabled: Schema uitgeschakeld
+Schedule disabled due to failed executions: Schema uitgeschakeld vanwege mislukte uitvoeringen
+Schedule ID: %scheduleId%: Schema-identificatie: %scheduleId%
+Schedule name: %scheduleCaption%: Schemanaam: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Accountactivering
 SUPLA - Account Removal: SUPLA - Account verwijderen
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Toestel ontgrendelen voor een gecertificeerde installateur
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA - melding over mislukte aanmelding bij %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - nieuwe cliëntapplicatie geregistreerd
 SUPLA – new device has been added to your account: SUPLA - een nieuw apparaat is toegevoegd aan uw account
+SUPLA – schedule disabled due to failed executions: SUPLA – schema uitgeschakeld vanwege mislukte uitvoeringen
 SUPLA – your device has been unlocked!: SUPLA - Uw toestel is ontgrendeld!
 SUPLA.ORG Team: Het SUPLA.ORG-team
 Same as on master thermostat.: Dezelfde instelling als op de hoofdthermostaat.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Uw privé SUPLA cloud is bijna geregistreerd.
 Your private SUPLA Cloud is not registered.: Uw private cloud SUPLA is niet geregistreerd.
 Your scenes are allowed to have a maximum of {max} operations.: Uw scènes kunnen een maximum hebben van {max} operaties.
+Your schedule has been disabled automatically due to repeated failed executions.: Uw schema is automatisch uitgeschakeld vanwege herhaaldelijk mislukte uitvoeringen.
 Your schedules are allowed to have a maximum of {max} actions.: Uw schema's kunnen een maximum van {max} aandelen hebben.
 Your session has been expired.: Uw sessie is verlopen.
 Your session is about to expire: Je sessie verloopt zo

--- a/translations/messages.pl.yml
+++ b/translations/messages.pl.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...możesz monitorować temperaturę
 10 minutes before sunset, on day 10 of the month, May through August: 10 minut przed zachodem słońca, tylko 10. dnia miesiąca, od maja do sierpnia
 15 minutes after sunrise, every 2 days: 15 minut po wschodzie słońca, co drugi dzień
+A confirmation that your schedule has been disabled automatically.: Potwierdzenie automatycznego wyłączenia harmonogramu.
 A confirmation upon successful client app registration.: Potwierdzenie rejestracji nowej aplikacji klienckiej.
 A confirmation upon successful device registration.: Potwierdzenie pomyślnej rejestracji urządzenia.
 A confirmation upon successful device unlocking.: Potwierdzenie odblokowania urządzenia.
@@ -183,6 +184,7 @@ Button volume: Głośność przycisku
 Buttons upside down: Odwrócone sterowanie przyciskami
 By signing in, you are authorizing {clientName} to control your devices.: Logując się, upoważniasz aplikację {clientName} do kontrolowania Twoich urządzeń.
 C++: C++
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Sprawdź historię harmonogramu i włącz go ponownie po usunięciu problemu.
 CLICK TO DISABLE: KLIKNIJ ABY WYŁĄCZYĆ
 CLICK TO ENABLE: KLIKNIJ ABY WŁĄCZYĆ
 Calibrate: Kalibruj
@@ -337,6 +339,7 @@ Custom execution limit: Niestandardowy limit wykonań
 DHT11 Temperature & Humidity Sensor: Czujnik temperatury i wilgotności DHT11
 DHT21 Temperature & Humidity Sensor: Czujnik temperatury i wilgotności DHT21
 DHT22 Temperature & Humidity Sensor: Czujnik temperatury i wilgotności DHT22
+Disabled due to failed executions: Wyłączono z powodu nieudanych wykonań
 DS18B20 Thermometer: Termometr DS18B20
 Dark mode: Tryb ciemny
 Data: Dane
@@ -959,6 +962,10 @@ Roller shutters: Rolety
 Roof window opening sensor: Czujnik otwarcia okna dachowego
 Roof window shutter operation: Otwieranie okna dachowego
 S/N: S/N
+Schedule disabled: Harmonogram wyłączony
+Schedule disabled due to failed executions: Wyłączenie harmonogramu z powodu nieudanych wykonań
+Schedule ID: %scheduleId%: ID harmonogramu: %scheduleId%
+Schedule name: %scheduleCaption%: Nazwa harmonogramu: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Aktywacja konta
 SUPLA - Account Removal: SUPLA - Usunięcie konta
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Odblokowanie urządzenia przeznaczonego dla certyfikowanego instalatora
@@ -973,6 +980,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Powiadomienie o nieudanym logowaniu do %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA – zarejestrowano nową aplikację kliencką
 SUPLA – new device has been added to your account: SUPLA - nowe urządzenie zostało dodane do Twojego konta
+SUPLA – schedule disabled due to failed executions: SUPLA – harmonogram wyłączony z powodu nieudanych wykonań
 SUPLA – your device has been unlocked!: SUPLA - Twoje urządzenie zostało odblokowane!
 SUPLA.ORG Team: Zespół SUPLA.ORG
 Same as on master thermostat.: Ustawienie takie samo jak w termostacie nadrzędnym.
@@ -1504,6 +1512,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Twoja prywatna chmura SUPLA jest prawie zarejestrowana.
 Your private SUPLA Cloud is not registered.: Twoja prywatna chmura SUPLA nie jest zarejestrowana.
 Your scenes are allowed to have a maximum of {max} operations.: Twoje sceny mogą mieć maksymalnie {max} operacji.
+Your schedule has been disabled automatically due to repeated failed executions.: Twój harmonogram został automatycznie wyłączony z powodu wielokrotnych nieudanych wykonań.
 Your schedules are allowed to have a maximum of {max} actions.: Twoje harmonogramy mogą mieć maksymalnie {max} akcji.
 Your session has been expired.: Twoja sesja wygasła.
 Your session is about to expire: Twoja sesja za chwilę wygaśnie

--- a/translations/messages.pt.yml
+++ b/translations/messages.pt.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...pode controlar a temperatura
 10 minutes before sunset, on day 10 of the month, May through August: 10 minutos antes do pôr do sol, apenas no dia 10 de cada mês, de maio a agosto
 15 minutes after sunrise, every 2 days: 15 minutos após o nascer do sol, em dias alternados
+A confirmation that your schedule has been disabled automatically.: Confirmação de que a agenda foi desativada automaticamente.
 A confirmation upon successful client app registration.: Confirmação do registo duma nova aplicação de um cliente.
 A confirmation upon successful device registration.: Confirmação do registo bem-sucedido do dispositivo.
 A confirmation upon successful device unlocking.: Confirmação do desbloqueio do dispositivo.
@@ -158,6 +159,7 @@ Brightness level: Nível de brilho
 Button volume: Volume do botão
 Buttons upside down: Controlo invertido por botões
 By signing in, you are authorizing {clientName} to control your devices.: Ao iniciar a sessão, autoriza a aplicação {clientName} a controlar os seus dispositivos.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Consulte o histórico da agenda para obter detalhes e reative-a depois de corrigir o problema.
 CLICK TO DISABLE: CLIQUE PARA DESLIGAR
 CLICK TO ENABLE: CLIQUE PARA LIGAR
 Calibrate: Calibrar
@@ -288,6 +290,7 @@ Custom execution limit: Limite de execuções personalizadas
 DHT11 Temperature & Humidity Sensor: Sensor da temperatura e da humidade DHT11
 DHT21 Temperature & Humidity Sensor: Sensor da temperatura e da humidade DHT21
 DHT22 Temperature & Humidity Sensor: Sensor da temperatura e da humidade DHT22
+Disabled due to failed executions: Desativada devido a execuções falhadas
 DS18B20 Thermometer: Termómetro DS18B20
 Dark mode: Modo escuro
 Data: Dados
@@ -820,6 +823,10 @@ Roller shutters: Estores
 Roof window opening sensor: Sensor de abertura do teto solar
 Roof window shutter operation: Abertura do teto solar
 S/N: S/N
+Schedule disabled: Agenda desativada
+Schedule disabled due to failed executions: Agenda desativada devido a execuções falhadas
+Schedule ID: %scheduleId%: Identificador da agenda: %scheduleId%
+Schedule name: %scheduleCaption%: Nome da agenda: %scheduleCaption%
 SUPLA - Account Activation: SUPLA – Ativar a conta
 SUPLA - Account Removal: Supla - deleção da conta
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Desbloqueio do dispositivo destinado a um instalador certificado
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Aviso de erro de login para %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - uma nova aplicação cliente foi registada
 SUPLA – new device has been added to your account: SUPLA - um novo dispositivo foi adicionado à sua conta
+SUPLA – schedule disabled due to failed executions: SUPLA – agenda desativada devido a execuções falhadas
 SUPLA – your device has been unlocked!: SUPLA - O seu dispositivo foi desbloqueado!
 SUPLA.ORG Team: Equipe da SUPLA.ORG
 Same as on master thermostat.: Configuração igual à do termóstato principal.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Sua nuvem SUPLA privada está quase registrada.
 Your private SUPLA Cloud is not registered.: Sua nuvem SUPLA privada não está registrada.
 Your scenes are allowed to have a maximum of {max} operations.: Os seus cenários podem ter no máximo {max} operações.
+Your schedule has been disabled automatically due to repeated failed executions.: A sua agenda foi desativada automaticamente devido a execuções falhadas repetidas.
 Your schedules are allowed to have a maximum of {max} actions.: Os seus agendamentos podem ter no máximo {max} ações.
 Your session has been expired.: A sua sessão expirou.
 Your session is about to expire: Sua sessão está prestes a expirar

--- a/translations/messages.ro.yml
+++ b/translations/messages.ro.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...puteți monitoriza temperatura
 10 minutes before sunset, on day 10 of the month, May through August: Cu 10 minute înainte de apus, numai în a 10-a zi a lunii, din mai până în august
 15 minutes after sunrise, every 2 days: La 15 minute după răsărit, o dată la două zile
+A confirmation that your schedule has been disabled automatically.: Confirmarea dezactivării automate a planului de execuție.
 A confirmation upon successful client app registration.: Confirmarea înregistrării unei noi aplicații de client.
 A confirmation upon successful device registration.: Confirmarea înregistrării cu succes a dispozitivului.
 A confirmation upon successful device unlocking.: Confirmarea deblocării dispozitivului.
@@ -158,6 +159,7 @@ Brightness level: Nivelul de luminozitate
 Button volume: Volumul butonului
 Buttons upside down: Controlul butonului de mers înapoi
 By signing in, you are authorizing {clientName} to control your devices.: Prin conectare, autorizezi aplicația {clientName} pentru controlul dispozitivelor tale.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Verificați istoricul planului pentru detalii și reactivați planul după remedierea problemei.
 CLICK TO DISABLE: FACEȚI CLIC PENTRU A DEZACTIVA
 CLICK TO ENABLE: FACEȚI CLIC PENTRU A ACTIVA
 Calibrate: Calibrează
@@ -288,6 +290,7 @@ Custom execution limit: Limită de executări particularizată
 DHT11 Temperature & Humidity Sensor: Senzor de temperatură și umiditate DHT11
 DHT21 Temperature & Humidity Sensor: Senzor de temperatură și umiditate DHT21
 DHT22 Temperature & Humidity Sensor: Senzor de temperatură și umiditate DHT22
+Disabled due to failed executions: Dezactivat din cauza execuțiilor eșuate
 DS18B20 Thermometer: Termometru DS18B20
 Dark mode: Mod întunecat
 Data: Date
@@ -820,6 +823,10 @@ Roller shutters: Jaluzele
 Roof window opening sensor: Senzor deschidere fereastră de mansardă
 Roof window shutter operation: Deschidere fereastră de mansardă
 S/N: S/N
+Schedule disabled: Plan de execuție dezactivat
+Schedule disabled due to failed executions: Plan de execuție dezactivat din cauza execuțiilor eșuate
+Schedule ID: %scheduleId%: Identificator plan: %scheduleId%
+Schedule name: %scheduleCaption%: Nume plan: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Activarea contului
 SUPLA - Account Removal: SUPLA - Ștergerea contului
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Deblocarea unui dispozitiv pentru un instalator certificat
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Notificare despre o conectare eșuată la %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - a fost înregistrată o nouă aplicație client
 SUPLA – new device has been added to your account: SUPLA - un dispozitiv nou a fost adăugat în contul dvs
+SUPLA – schedule disabled due to failed executions: SUPLA – plan de execuție dezactivat din cauza execuțiilor eșuate
 SUPLA – your device has been unlocked!: SUPLA - Dispozitivul dvs. a fost deblocat!
 SUPLA.ORG Team: Echipa SUPLA.ORG
 Same as on master thermostat.: Aceeași setare ca la termostatul principal.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Norul dvs. privat SUPLA este aproape înregistrat.
 Your private SUPLA Cloud is not registered.: Norul dvs. privat SUPLA nu este înregistrat.
 Your scenes are allowed to have a maximum of {max} operations.: Scenele dvs. pot avea maximum {max} operații.
+Your schedule has been disabled automatically due to repeated failed executions.: Planul dvs. a fost dezactivat automat din cauza execuțiilor eșuate repetate.
 Your schedules are allowed to have a maximum of {max} actions.: Programele dvs. pot avea maximum {max} acțiuni.
 Your session has been expired.: Sesiunea dvs. a expirat.
 Your session is about to expire: Sesiunea dvs. va expira îndată

--- a/translations/messages.ru.yml
+++ b/translations/messages.ru.yml
@@ -7,6 +7,7 @@
 ...you can monitor temperature: ...узнать температуру
 10 minutes before sunset, on day 10 of the month, May through August: За 10 минут до заката солнца, только 10. числа месяца, с мая по август
 15 minutes after sunrise, every 2 days: Через 15 минут после восхода солнца, через день
+A confirmation that your schedule has been disabled automatically.: Подтверждение автоматического отключения графика.
 A confirmation upon successful client app registration.: Подтверждение регистрации нового клиентского приложения.
 A confirmation upon successful device registration.: Подтверждение успешной регистрации устройства.
 A new client app (smartphone) been added to your SUPLA-Cloud account.: Новое клиентское приложение (смартфон) добавлено в вашу учетную запись SUPLA-Cloud.
@@ -105,6 +106,7 @@ Below threshold: Ниже порога
 Bottom position: Нижнее положение
 Bridge: Мост
 Brightness: Яркость
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Подробности см. в истории графика; после устранения проблемы включите график снова.
 CLICK TO DISABLE: ОТКЛЮЧИТЬ
 CLICK TO ENABLE: ИСПОЛЬЗОВАТЬ
 Calibrate: Калибровка
@@ -193,6 +195,7 @@ Custom execution limit: Нестандартный лимит исполнени
 DHT11 Temperature & Humidity Sensor: Датчик температуры и влажности DHT11
 DHT21 Temperature & Humidity Sensor: Датчик температуры и влажности DHT21
 DHT22 Temperature & Humidity Sensor: Датчик температуры и влажности DHT22
+Disabled due to failed executions: Отключено из-за неудачных выполнений
 DS18B20 Thermometer: Термометр DS18B20
 Data saved: Данные сохранены
 Date: Дата
@@ -551,6 +554,10 @@ Roller shutter operation: Управление роллетами
 Roller shutters: Роллеты
 Roof window opening sensor: Датчик открытия окна крыши
 Roof window shutter operation: Открытие окна крыши
+Schedule disabled: График отключен
+Schedule disabled due to failed executions: График отключен из-за неудачных выполнений
+Schedule ID: %scheduleId%: Идентификатор графика: %scheduleId%
+Schedule name: %scheduleCaption%: Название графика: %scheduleCaption%
 SUPLA - Account Activation: Активация аккаунта SUPLA
 SUPLA - Account Removal: SUPLA - Удаление учетной записи
 SUPLA - Password reset: Сброс пароля для SUPLA
@@ -563,6 +570,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Уведомление о неудачной попытке входа в %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - зарегистрировано новое клиентское приложение
 SUPLA – new device has been added to your account: SUPLA - новое устройство добавлено в вашу учетную запись
+SUPLA – schedule disabled due to failed executions: SUPLA – график отключен из-за неудачных выполнений
 SUPLA.ORG Team: Команда SUPLA.ORG
 Saturdays: Субботы
 Save: Сохранить
@@ -772,6 +780,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Ваше персональное облако SUPLA почти зарегистрировано.
 Your private SUPLA Cloud is not registered.: Ваше личное облако SUPLA не зарегистрировано.
 Your scenes are allowed to have a maximum of {max} operations.: Ваши сцены могут иметь максимум {max} операций.
+Your schedule has been disabled automatically due to repeated failed executions.: Ваш график был автоматически отключен из-за повторяющихся неудачных выполнений.
 Your schedules are allowed to have a maximum of {max} actions.: Ваши графики могут иметь максимум {max} действий.
 Your session has been expired.: Ваш сеанс завершен.
 Your session is about to expire: Ваша сессия истекает

--- a/translations/messages.sk.yml
+++ b/translations/messages.sk.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...môžete monitorovať teplotu
 10 minutes before sunset, on day 10 of the month, May through August: 10 minút pred západom slnka, iba v 10. deň v mesiaci, od mája do augusta
 15 minutes after sunrise, every 2 days: 15 minút po východe slnka, každý druhý deň
+A confirmation that your schedule has been disabled automatically.: Potvrdenie automatického vypnutia harmonogramu.
 A confirmation upon successful client app registration.: Potvrdenie registrácie novej klientskej aplikácie.
 A confirmation upon successful device registration.: Potvrdenie úspešnej registrácie zariadenia.
 A confirmation upon successful device unlocking.: Potvrdenie odomknutia zariadenia.
@@ -158,6 +159,7 @@ Brightness level: Úroveň jasu
 Button volume: Hlasitosť tlačidla
 Buttons upside down: Ovládanie tlačidla spätného chodu
 By signing in, you are authorizing {clientName} to control your devices.: Prihlásením autorizujete aplikáciu {clientName} na kontrolu vašich zariadení.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Podrobnosti nájdete v histórii harmonogramu a harmonogram znova zapnite po odstránení problému.
 CLICK TO DISABLE: STLAČENÍM VYPNETE
 CLICK TO ENABLE: STLAČENÍM ZAPNETE
 Calibrate: Kalibrovať
@@ -288,6 +290,7 @@ Custom execution limit: Neštandardný limit vykonaní
 DHT11 Temperature & Humidity Sensor: Snímač teploty a vlhkosti DHT11
 DHT21 Temperature & Humidity Sensor: Snímač teploty a vlhkosti DHT21
 DHT22 Temperature & Humidity Sensor: Snímač teploty a vlhkosti DHT22
+Disabled due to failed executions: Vypnuté kvôli neúspešným vykonaniam
 DS18B20 Thermometer: Teplomer DS18B20
 Dark mode: Tmavý režim
 Data: Údaje
@@ -820,6 +823,10 @@ Roller shutters: Rolety
 Roof window opening sensor: Senzor otvárania strešného okna
 Roof window shutter operation: Otváranie strešného okna
 S/N: S/N
+Schedule disabled: Harmonogram vypnutý
+Schedule disabled due to failed executions: Harmonogram vypnutý kvôli neúspešným vykonaniam
+Schedule ID: %scheduleId%: Identifikátor harmonogramu: %scheduleId%
+Schedule name: %scheduleCaption%: Názov harmonogramu: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Aktivácia účtu
 SUPLA - Account Removal: SUPLA – Zrušenie účtu
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Odblokovanie zariadenia pre certifikovaného inštalatéra
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA – Oznámenie o neúspešnom prihlásení do %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - bola zaregistrovaná nová klientská aplikácia
 SUPLA – new device has been added to your account: SUPLA – do vášho účtu bolo pridané nové zariadenie
+SUPLA – schedule disabled due to failed executions: SUPLA – harmonogram vypnutý kvôli neúspešným vykonaniam
 SUPLA – your device has been unlocked!: SUPLA - Vaše zariadenie bolo odomknuté!
 SUPLA.ORG Team: Tím SUPLA.ORG
 Same as on master thermostat.: Rovnaké nastavenie ako na hlavnom termostate.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Váš súkromný mrak SUPLA je skoro zaregistrovaný.
 Your private SUPLA Cloud is not registered.: Váš súkromný cloud SUPLA nie je registrovaný.
 Your scenes are allowed to have a maximum of {max} operations.: Vaše scény môžu mať maximálne {max} operácií.
+Your schedule has been disabled automatically due to repeated failed executions.: Váš harmonogram bol automaticky vypnutý kvôli opakovaným neúspešným vykonaniam.
 Your schedules are allowed to have a maximum of {max} actions.: Vaše harmonogramy môžu obsahovať maximálne {max} akcií.
 Your session has been expired.: Vaša relácia vypršala.
 Your session is about to expire: Vaša relácia čoskoro vyprší

--- a/translations/messages.sl.yml
+++ b/translations/messages.sl.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...lahko spremljate temperaturo
 10 minutes before sunset, on day 10 of the month, May through August: 10 minut pred sončnim zahodom, samo 10. dan v mesecu, od maja do avgusta
 15 minutes after sunrise, every 2 days: 15 minut po sončnem vzhodu, vsak drugi dan
+A confirmation that your schedule has been disabled automatically.: Potrditev samodejnega izklopa urnika.
 A confirmation upon successful client app registration.: Potrdilo registracije nove odjemalske aplikacije.
 A confirmation upon successful device registration.: Potrdilo uspešne registracije naprave.
 A confirmation upon successful device unlocking.: Potrditev odklepanja naprave.
@@ -158,6 +159,7 @@ Brightness level: Stopnja svetlosti
 Button volume: Glasnost gumba
 Buttons upside down: Upravljanje z gumbom za vzvratni pogon
 By signing in, you are authorizing {clientName} to control your devices.: S prijavo pooblastite aplikacijo {clientName} za nadzor vaših naprav.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Podrobnosti preverite v zgodovini urnika in urnik znova vklopite po odpravi težave.
 CLICK TO DISABLE: KLIKNITE, DA SE IZKLOPITE
 CLICK TO ENABLE: KLIKNITE, DA VKLOPITE
 Calibrate: Umeri
@@ -288,6 +290,7 @@ Custom execution limit: Omejitev zmogljivosti po meri
 DHT11 Temperature & Humidity Sensor: DHT11 senzor temperature in vlažnosti
 DHT21 Temperature & Humidity Sensor: DHT21 senzor temperature in vlažnosti
 DHT22 Temperature & Humidity Sensor: DHT22 senzor temperature in vlažnosti
+Disabled due to failed executions: Onemogočeno zaradi neuspešnih izvedb
 DS18B20 Thermometer: DS18B20 termometer
 Dark mode: Temni način
 Data: Podatki
@@ -820,6 +823,10 @@ Roller shutters: Rolete
 Roof window opening sensor: Senzor odpiranja strešnega okna
 Roof window shutter operation: Odpiranje strešnega okna
 S/N: S/N
+Schedule disabled: Urnik izklopljen
+Schedule disabled due to failed executions: Urnik onemogočen zaradi neuspešnih izvedb
+Schedule ID: %scheduleId%: Identifikator urnika: %scheduleId%
+Schedule name: %scheduleCaption%: Ime urnika: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Aktivacija računa
 SUPLA - Account Removal: SUPLA - Brisanje računa
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Odklepanje naprave za pooblaščenega monterja
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA - Obvestilo o neuspešni prijavi na %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA – registracija nove odjemalske aplikacije
 SUPLA – new device has been added to your account: SUPLA – nova naprava je bila dodana v vaš račun
+SUPLA – schedule disabled due to failed executions: SUPLA – urnik onemogočen zaradi neuspešnih izvedb
 SUPLA – your device has been unlocked!: SUPLA - Vaša naprava je bila odklenjena!
 SUPLA.ORG Team: Skupina SUPLA.ORG
 Same as on master thermostat.: Nastavitev je enaka kot na glavnem termostatu.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Vaš zasebni oblak SUPLA je skoraj registriran.
 Your private SUPLA Cloud is not registered.: Vaš zasebni oblak SUPLA ni registriran.
 Your scenes are allowed to have a maximum of {max} operations.: Vaše scene lahko imajo največ {max} operacij.
+Your schedule has been disabled automatically due to repeated failed executions.: Vaš urnik je bil samodejno onemogočen zaradi ponavljajočih se neuspešnih izvedb.
 Your schedules are allowed to have a maximum of {max} actions.: Vaši urniki lahko imajo največ {max} dejanj.
 Your session has been expired.: Vaša seja je potekla.
 Your session is about to expire: Vaša seja poteče čez trenutek

--- a/translations/messages.uk.yml
+++ b/translations/messages.uk.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...можна стежити за температурою
 10 minutes before sunset, on day 10 of the month, May through August: за 10 хвилин до заходу сонця, лише у 10-й день місяця, з травня по серпень
 15 minutes after sunrise, every 2 days: 15 хвилин після сходу сонця, через день
+A confirmation that your schedule has been disabled automatically.: Підтвердження автоматичного вимкнення розкладу.
 A confirmation upon successful client app registration.: Підтвердження реєстрації  заявки нового клієнта.
 A confirmation upon successful device registration.: Підтвердження успішної реєстрації пристрою.
 A confirmation upon successful device unlocking.: Підтвердження розблокування пристрою.
@@ -158,6 +159,7 @@ Brightness level: Рівень яскравості
 Button volume: Кнопка гучності
 Buttons upside down: Керування кнопкою реверсу
 By signing in, you are authorizing {clientName} to control your devices.: Увійшовши в систему, ви дозволяєте додатку {clientName} керувати вашими пристроями.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Перегляньте історію розкладу для деталей і увімкніть розклад знову після усунення проблеми.
 CLICK TO DISABLE: НАТИСНІТЬ, ЩОБ ВИМКНУТИ
 CLICK TO ENABLE: НАТИСНІТЬ, ЩОБ УВІМКНУТИ
 Calibrate: Відкалібрувати
@@ -288,6 +290,7 @@ Custom execution limit: Користувацький ліміт виконанн
 DHT11 Temperature & Humidity Sensor: Датчик температури та вологості DHT11
 DHT21 Temperature & Humidity Sensor: Датчик температури та вологості DHT21
 DHT22 Temperature & Humidity Sensor: Датчик температури та вологості DHT22
+Disabled due to failed executions: Вимкнено через невдалі виконання
 DS18B20 Thermometer: Термометр DS18B20
 Dark mode: Темний режим
 Data: Дані
@@ -820,6 +823,10 @@ Roller shutters: Ролети
 Roof window opening sensor: Датчик відкриття вікна даху
 Roof window shutter operation: Відкриття вікна даху
 S/N: Серійний номер
+Schedule disabled: Розклад вимкнено
+Schedule disabled due to failed executions: Розклад вимкнено через невдалі виконання
+Schedule ID: %scheduleId%: Ідентифікатор розкладу: %scheduleId%
+Schedule name: %scheduleCaption%: Назва розкладу: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - активація облікового запису
 SUPLA - Account Removal: SUPLA - Видалення облікового запису
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Розблокування пристрою для сертифікованого інсталятора
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA - Сповіщення про невдалий вхід до %cloudHost%
 SUPLA – new client app has been added to your account: SUPLA - зареєстровано новий клієнтський додаток
 SUPLA – new device has been added to your account: SUPLA - до вашого облікового запису додано новий пристрій
+SUPLA – schedule disabled due to failed executions: SUPLA – розклад вимкнено через невдалі виконання
 SUPLA – your device has been unlocked!: SUPLA - Ваш пристрій розблоковано!
 SUPLA.ORG Team: Команда SUPLA.ORG
 Same as on master thermostat.: Ті самі налаштування, що й на головному термостаті.
@@ -1277,6 +1285,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Ваша приватна хмара SUPLA майже зареєстрована.
 Your private SUPLA Cloud is not registered.: Ваша приватна хмара SUPLA не зареєстрована.
 Your scenes are allowed to have a maximum of {max} operations.: Ваші сцени можуть мати максимум {max} операцій.
+Your schedule has been disabled automatically due to repeated failed executions.: Ваш розклад було автоматично вимкнено через повторювані невдалі виконання.
 Your schedules are allowed to have a maximum of {max} actions.: Ваші розклади можуть мати максимум {max} дій.
 Your session has been expired.: Ваш сеанс закінчився.
 Your session is about to expire: Ваш сеанс скоро закінчиться

--- a/translations/messages.vi.yml
+++ b/translations/messages.vi.yml
@@ -8,6 +8,7 @@
 ...you can monitor temperature: ...bạn có thể theo dõi nhiệt độ
 10 minutes before sunset, on day 10 of the month, May through August: 10 phút trước khi mặt trời lặn, chỉ vào ngày mùng 10 của tháng, từ tháng 5 đến tháng 8
 15 minutes after sunrise, every 2 days: 15 phút sau khi mặt trời mọc, đều đặn cách 1 ngày
+A confirmation that your schedule has been disabled automatically.: Xác nhận lịch trình đã bị vô hiệu hóa tự động.
 A confirmation upon successful client app registration.: Xác nhận đăng ký ứng dụng khách hàng mới
 A confirmation upon successful device registration.: Xác nhận đăng ký thiết bị thành công.
 A confirmation upon successful device unlocking.: Xác nhận mở khóa thiết bị.
@@ -158,6 +159,7 @@ Brightness level: Mức độ sáng
 Button volume: Âm lượng nút bấm
 Buttons upside down: Điều khiển nút đảo ngược
 By signing in, you are authorizing {clientName} to control your devices.: Bằng cách đăng nhập, bạn cho phép ứng dụng {clientName} kiểm soát các thiết bị của bạn.
+Check the schedule history for details and re-enable the schedule after fixing the problem.: Kiểm tra lịch sử lịch trình để biết chi tiết và bật lại lịch trình sau khi khắc phục sự cố.
 CLICK TO DISABLE: CLICK TẮT
 CLICK TO ENABLE: CLICK BẬT
 Calibrate: Hiệu chỉnh
@@ -288,6 +290,7 @@ Custom execution limit: Giới hạn tùy chỉnh
 DHT11 Temperature & Humidity Sensor: Cảm biến nhiệt & độ ẩm DHT11
 DHT21 Temperature & Humidity Sensor: Cảm biến nhiệt & độ ẩm DHT21
 DHT22 Temperature & Humidity Sensor: Cảm biến nhiệt & độ ẩm DHT22
+Disabled due to failed executions: Đã vô hiệu hóa do thực thi không thành công
 DS18B20 Thermometer: Nhiệt kế DS18B20
 Dark mode: Chế độ tối
 Data: Dữ liệu
@@ -820,6 +823,10 @@ Roller shutters: Cửa chớp lăn
 Roof window opening sensor: Cảm biến mở của sổ mái nhà
 Roof window shutter operation: Mở của sổ mái nhà
 S/N: Tỷ lệ tín hiệu trên tạp âm
+Schedule disabled: Lịch trình đã bị vô hiệu hóa
+Schedule disabled due to failed executions: Lịch trình bị vô hiệu hóa do thực thi không thành công
+Schedule ID: %scheduleId%: ID lịch trình: %scheduleId%
+Schedule name: %scheduleCaption%: Tên lịch trình: %scheduleCaption%
 SUPLA - Account Activation: SUPLA - Kích hoạt tài khoản
 SUPLA - Account Removal: SUPLA - Xóa tài khoản
 SUPLA - Confirm unlocking device for authorized installers: SUPLA - Mở khóa thiết bị dành cho người được chứng nhận cài đặt
@@ -833,6 +840,7 @@ SUPLA is available from anywhere at any time, so do not worry, if you forget to 
 SUPLA – %cloudHost% unsuccessful login attempt notification: SUPLA - %cloudHost% thông báo cố gắng đăng nhập không thành công
 SUPLA – new client app has been added to your account: SUPLA – đã đăng kí một ứng dụng client mới
 SUPLA – new device has been added to your account: SUPLA – đã thêm một thiết bị mới vào tài khoản của bạn
+SUPLA – schedule disabled due to failed executions: SUPLA – lịch trình bị vô hiệu hóa do thực thi không thành công
 SUPLA – your device has been unlocked!: SUPLA - Thiết bị của bạn đã được mở khóa!
 SUPLA.ORG Team: Đội SUPLA.ORG
 Same as on master thermostat.: Cài đặt giống như trong bộ điều chỉnh nhiệt chính.
@@ -1278,6 +1286,7 @@ Your private SUPLA Cloud instance is not available. Make sure your server is onl
 Your private SUPLA Cloud is almost registered.: Đám mây SUPLA riêng tư của bạn gần như đã được đăng ký.
 Your private SUPLA Cloud is not registered.: Đám mây SUPLA riêng tư của bạn chưa được đăng ký.
 Your scenes are allowed to have a maximum of {max} operations.: Những hoạt cảnh của bạn có thể có tối đa {max} thao tác.
+Your schedule has been disabled automatically due to repeated failed executions.: Lịch trình của bạn đã bị vô hiệu hóa tự động do nhiều lần thực thi không thành công.
 Your schedules are allowed to have a maximum of {max} actions.: Những lịch biểu của bạn có thể có tối đa {max} hành động.
 Your session has been expired.: Phiên của bạn đã hết hạn.
 Your session is about to expire: Phiên bản của bạn sắp hết hạn


### PR DESCRIPTION
## What does this PR change?

When the cyclic `supla:clean:disable-broken-schedules` command disables a schedule (0 successful and >10 failed executions in the last month), the user is now informed in two ways:
- **E-mail** (and optional push via existing `CommonMessage` flow) with schedule details and a link to SUPLA-Cloud
- **Schedule history** — a new past execution entry with result `Disabled due to failed executions`

## Checklist

- [x] Linked issue / rationale provided: https://github.com/SUPLA/supla-cloud/issues/1054
- [x] Code follows existing style and conventions
- [x] Documentation updated if needed
- [x] CLA accepted (requested automatically after opening the PR)
- [x] Tests added/updated (if applicable)
- [x] No secrets in logs/config

